### PR TITLE
Don't allow scripts to close windows.

### DIFF
--- a/embedding/embedlite/embedding.js
+++ b/embedding/embedlite/embedding.js
@@ -302,4 +302,5 @@ pref("extensions.minCompatibleAppVersion", "11.0");
 
 // Enable sub layers for apzc
 pref("layout.want.subapzc", true);
-pref("dom.allow_scripts_to_close_windows", true);
+pref("dom.allow_scripts_to_close_windows", false);
+pref("dom.disable_window_open_feature.close", false);


### PR DESCRIPTION
This opens up too much problems, e.i. handling root window close not allowed. 

This proposed preferences e.g. feedly login seems to work fine.
It should be enough that "dom.disable_window_open_feature.close" is false (window.close()
working from child window).
