### PR TITLE
Initialize content listeners with frame metrics as soon as they are known

### DIFF
--- a/embedding/embedlite/embedthread/EmbedLiteViewThreadChild.cpp
+++ b/embedding/embedlite/embedthread/EmbedLiteViewThreadChild.cpp
@@ -594,10 +594,7 @@ EmbedLiteViewThreadChild::RecvUpdateFrame(const FrameMetrics& aFrameMetrics)
     mViewResized = false;
   }
 
-
-  for (unsigned int i = 0; i < mControllerListeners.Length(); i++) {
-    mControllerListeners[i]->RequestContentRepaint(metrics);
-  }
+  RelayFrameMetrics(metrics);
 
   bool ret = true;
   if (sHandleDefaultAZPC.viewport) {
@@ -605,6 +602,14 @@ EmbedLiteViewThreadChild::RecvUpdateFrame(const FrameMetrics& aFrameMetrics)
   }
 
   return ret;
+}
+
+void
+EmbedLiteViewThreadChild::RelayFrameMetrics(const FrameMetrics& aFrameMetrics)
+{
+  for (unsigned int i = 0; i < mControllerListeners.Length(); i++) {
+    mControllerListeners[i]->RequestContentRepaint(aFrameMetrics);
+  }
 }
 
 bool

--- a/embedding/embedlite/embedthread/EmbedLiteViewThreadChild.h
+++ b/embedding/embedlite/embedthread/EmbedLiteViewThreadChild.h
@@ -120,6 +120,10 @@ private:
   friend class EmbedLiteAppService;
   friend class EmbedLiteAppThreadChild;
 
+  /**
+   * Relay given frame metrics to listeners subscribed via EmbedLiteAppService
+   */
+  void RelayFrameMetrics(const mozilla::layers::FrameMetrics& aFrameMetrics);
   void InitGeckoWindow(const uint32_t& parentId);
   EmbedLiteAppThreadChild* AppChild();
   void InitEvent(WidgetGUIEvent& event, nsIntPoint* aPoint = nullptr);

--- a/embedding/embedlite/utils/TabChildHelper.cpp
+++ b/embedding/embedlite/utils/TabChildHelper.cpp
@@ -240,6 +240,8 @@ TabChildHelper::Observe(nsISupports* aSubject,
           utils->SetResolution(mLastRootMetrics.mResolution.scale,
                                mLastRootMetrics.mResolution.scale);
           HandlePossibleViewportChange();
+          // Relay frame metrics to subscribed listeners
+          mView->RelayFrameMetrics(mLastRootMetrics);
         }
       }
 
@@ -265,6 +267,8 @@ TabChildHelper::HandleEvent(nsIDOMEvent* aEvent)
     // This meta data may or may not have been a meta viewport tag. If it was,
     // we should handle it immediately.
     HandlePossibleViewportChange();
+    // Relay frame metrics to subscribed listeners
+    mView->RelayFrameMetrics(mLastRootMetrics);
   }
 
   return NS_OK;


### PR DESCRIPTION
EmbedTouchListener needs to know frame metrics as soon as they are known in order to ZoomToElement upon double tap before AZPC::RequestContentRepaint() is called (i.e. right after browser start and before any panning or pinching).
