### PR TITLE
Call nsIEmbedBrowserChromeListener::OnLocationChanged with an exposable url

### DIFF
--- a/embedding/embedlite/utils/WebBrowserChrome.cpp
+++ b/embedding/embedlite/utils/WebBrowserChrome.cpp
@@ -28,6 +28,7 @@
 #include "nsIFocusManager.h"
 #include "nsIDOMScrollAreaEvent.h"
 #include "nsISerializable.h"
+#include "nsIURIFixup.h"
 #include "nsIEmbedBrowserChromeListener.h"
 #include "nsIBaseWindow.h"
 
@@ -258,7 +259,18 @@ WebBrowserChrome::OnLocationChange(nsIWebProgress* aWebProgress,
 
   nsCString spec;
   if (location) {
-    location->GetSpec(spec);
+    nsCOMPtr<nsIURIFixup> fixup(do_GetService("@mozilla.org/docshell/urifixup;1"));
+    if (fixup) {
+        nsCOMPtr<nsIURI> tmpuri;
+        nsresult rv = fixup->CreateExposableURI(location, getter_AddRefs(tmpuri));
+        if (NS_SUCCEEDED(rv) && tmpuri) {
+            tmpuri->GetSpec(spec);
+        } else {
+            location->GetSpec(spec);
+        }
+    } else {
+        location->GetSpec(spec);
+    }
   }
   nsCString slocation(spec);
   int32_t i = slocation.RFind("#");


### PR DESCRIPTION
Previously we were calling nsIEmbedBrowserChromeListener::OnLocationChanged
with a raw internal url. The raw url might have contained e.g. wyciwyg
scheme.
