### PR TITLE
[embedlite] Don't resume unsuspended view

### DIFF
--- a/embedding/embedlite/embedthread/EmbedLiteViewThreadChild.cpp
+++ b/embedding/embedlite/embedthread/EmbedLiteViewThreadChild.cpp
@@ -393,8 +393,10 @@ EmbedLiteViewThreadChild::RecvResumeTimeouts()
   nsCOMPtr<nsPIDOMWindow> pwindow(do_QueryInterface(mDOMWindow, &rv));
   NS_ENSURE_SUCCESS(rv, false);
 
-  rv = pwindow->ResumeTimeouts();
-  NS_ENSURE_SUCCESS(rv, false);
+  if (pwindow->TimeoutSuspendCount()) {
+    rv = pwindow->ResumeTimeouts();
+    NS_ENSURE_SUCCESS(rv, false);
+  }
 
   return true;
 }


### PR DESCRIPTION
nsGlobalWindow::ResumeTimeouts() is not idempotent method. For every resume there must be a corresponding suspend.
