### PR TITLE
[embedlite] Avoid sending messages to non-existing render frame actor

### DIFF
--- a/embedding/embedlite/embedthread/EmbedContentController.cpp
+++ b/embedding/embedlite/embedthread/EmbedContentController.cpp
@@ -50,7 +50,7 @@ void EmbedContentController::HandleDoubleTap(const CSSPoint& aPoint, int32_t aMo
       NewRunnableMethod(this, &EmbedContentController::HandleDoubleTap, aPoint, aModifiers, aGuid));
     return;
   }
-  if (!GetListener()->HandleDoubleTap(nsIntPoint(aPoint.x, aPoint.y))) {
+  if (mRenderFrame && !GetListener()->HandleDoubleTap(nsIntPoint(aPoint.x, aPoint.y))) {
     unused << mRenderFrame->SendHandleDoubleTap(nsIntPoint(aPoint.x, aPoint.y));
   }
 }
@@ -65,7 +65,7 @@ void EmbedContentController::HandleSingleTap(const CSSPoint& aPoint, int32_t aMo
       NewRunnableMethod(this, &EmbedContentController::HandleSingleTap, aPoint, aModifiers, aGuid));
     return;
   }
-  if (!GetListener()->HandleSingleTap(nsIntPoint(aPoint.x, aPoint.y))) {
+  if (mRenderFrame && !GetListener()->HandleSingleTap(nsIntPoint(aPoint.x, aPoint.y))) {
     unused << mRenderFrame->SendHandleSingleTap(nsIntPoint(aPoint.x, aPoint.y));
   }
 }
@@ -80,7 +80,7 @@ void EmbedContentController::HandleLongTap(const CSSPoint& aPoint, int32_t aModi
       NewRunnableMethod(this, &EmbedContentController::HandleLongTap, aPoint, aModifiers, aGuid));
     return;
   }
-  if (!GetListener()->HandleLongTap(nsIntPoint(aPoint.x, aPoint.y))) {
+  if (mRenderFrame && !GetListener()->HandleLongTap(nsIntPoint(aPoint.x, aPoint.y))) {
     unused << mRenderFrame->SendHandleLongTap(nsIntPoint(aPoint.x, aPoint.y));
   }
 }
@@ -112,7 +112,7 @@ void EmbedContentController::SendAsyncScrollDOMEvent(bool aIsRoot,
     aScrollableSize.width, aScrollableSize.height);
   gfxRect rect(aContentRect.x, aContentRect.y, aContentRect.width, aContentRect.height);
   gfxSize size(aScrollableSize.width, aScrollableSize.height);
-  if (aIsRoot && !GetListener()->SendAsyncScrollDOMEvent(rect, size)) {
+  if (mRenderFrame && aIsRoot && !GetListener()->SendAsyncScrollDOMEvent(rect, size)) {
     unused << mRenderFrame->SendAsyncScrollDOMEvent(rect, size);
   }
 }
@@ -127,7 +127,7 @@ void EmbedContentController::AcknowledgeScrollUpdate(const FrameMetrics::ViewID&
       NewRunnableMethod(this, &EmbedContentController::AcknowledgeScrollUpdate, aScrollId, aScrollGeneration));
     return;
   }
-  if (!GetListener()->AcknowledgeScrollUpdate((uint32_t)aScrollId, aScrollGeneration)) {
+  if (mRenderFrame && !GetListener()->AcknowledgeScrollUpdate((uint32_t)aScrollId, aScrollGeneration)) {
     unused << mRenderFrame->SendAcknowledgeScrollUpdate(aScrollId, aScrollGeneration);
   }
 }
@@ -173,7 +173,7 @@ EmbedLiteViewListener* const EmbedContentController::GetListener() const
 
 void EmbedContentController::DoRequestContentRepaint(const FrameMetrics& aFrameMetrics)
 {
-  if (!GetListener()->RequestContentRepaint()) {
+  if (mRenderFrame && !GetListener()->RequestContentRepaint()) {
     unused << mRenderFrame->SendUpdateFrame(aFrameMetrics);
   }
 }

--- a/embedding/embedlite/embedthread/EmbedLiteViewThreadParent.cpp
+++ b/embedding/embedlite/embedthread/EmbedLiteViewThreadParent.cpp
@@ -647,6 +647,9 @@ EmbedLiteViewThreadParent::TextEvent(const char* composite, const char* preEdit)
 NS_IMETHODIMP
 EmbedLiteViewThreadParent::ViewAPIDestroyed()
 {
+  if (mController) {
+    mController->ClearRenderFrame();
+  }
   mViewAPIDestroyed = true;
   mView = nullptr;
 


### PR DESCRIPTION
Currently LongTap timeout can trigger a call to non-existing "render frame"
