### PR TITLE
Drop unused member EmbedLiteCompositorParent.mChildMessageLoop

### DIFF
--- a/embedding/embedlite/embedthread/EmbedLiteCompositorParent.cpp
+++ b/embedding/embedlite/embedthread/EmbedLiteCompositorParent.cpp
@@ -212,10 +212,9 @@ void EmbedLiteCompositorParent::SetClipping(const gfxRect& aClipRect)
 }
 
 void
-EmbedLiteCompositorParent::SetChildCompositor(CompositorChild* aCompositorChild, MessageLoop* childLoop)
+EmbedLiteCompositorParent::SetChildCompositor(CompositorChild* aCompositorChild)
 {
   LOGT();
-  mChildMessageLoop = childLoop;
   mChildCompositor = aCompositorChild;
 }
 

--- a/embedding/embedlite/embedthread/EmbedLiteCompositorParent.h
+++ b/embedding/embedlite/embedthread/EmbedLiteCompositorParent.h
@@ -35,7 +35,7 @@ public:
   void SetWorldOpacity(float aOpacity);
   void* GetPlatformImage(int* width, int* height);
 
-  virtual void SetChildCompositor(mozilla::layers::CompositorChild*, MessageLoop*);
+  virtual void SetChildCompositor(mozilla::layers::CompositorChild*);
   mozilla::layers::CompositorChild* GetChildCompositor() {
     return mChildCompositor;
   }
@@ -55,7 +55,6 @@ protected:
   bool IsGLBackend();
 
   RefPtr<mozilla::layers::CompositorChild> mChildCompositor;
-  MessageLoop* mChildMessageLoop;
   uint32_t mId;
   gfx::Matrix mWorldTransform;
   nsIntRect mActiveClipping;

--- a/embedding/embedlite/embedthread/EmbedLitePuppetWidget.cpp
+++ b/embedding/embedlite/embedthread/EmbedLitePuppetWidget.cpp
@@ -519,7 +519,7 @@ void EmbedLitePuppetWidget::CreateCompositor(int aWidth, int aHeight)
   ClientLayerManager* lm = new ClientLayerManager(this);
   MessageLoop* childMessageLoop = CompositorParent::CompositorLoop();
   mCompositorChild = new CompositorChild(lm);
-  static_cast<EmbedLiteCompositorParent*>(mCompositorParent.get())->SetChildCompositor(mCompositorChild, MessageLoop::current());
+  static_cast<EmbedLiteCompositorParent*>(mCompositorParent.get())->SetChildCompositor(mCompositorChild);
   mCompositorChild->Open(parentChannel, childMessageLoop, ipc::ChildSide);
 
   TextureFactoryIdentifier textureFactoryIdentifier;


### PR DESCRIPTION
This unused member got factored out in the latest embedlite branch, but still exists in embedlite_31.
