### PR TITLE
Add EmbedLiteView::Repaint() API

### DIFF
--- a/embedding/embedlite/embedthread/EmbedLiteViewThreadParent.cpp
+++ b/embedding/embedlite/embedthread/EmbedLiteViewThreadParent.cpp
@@ -410,6 +410,7 @@ EmbedLiteViewThreadParent::ResumeRendering()
 {
   if (mCompositor) {
     mCompositor->ResumeRendering();
+    mCompositor->ScheduleRenderOnCompositorThread();
   }
 
   return NS_OK;


### PR DESCRIPTION
in order to repaint recreated GL buffer.

I'm not sure the code of EmbedLiteViewThreadChild::RecvRepaint() is optimal, but it works.
