### PR TITLE
Don't recalculate viewport until before-first-paint is emitted

### DIFF
--- a/embedding/embedlite/embedthread/EmbedLiteCompositorParent.cpp
+++ b/embedding/embedlite/embedthread/EmbedLiteCompositorParent.cpp
@@ -118,7 +118,7 @@ EmbedLiteCompositorParent::UpdateTransformState()
   NS_ENSURE_TRUE(context, );
 
   if (context->IsOffscreen() && context->OffscreenSize() != mLastViewSize) {
-    context->ResizeOffscreen(gfx::IntSize(mLastViewSize.width, mLastViewSize.height));
+    context->ResizeOffscreen(mLastViewSize);
     ScheduleRenderOnCompositorThread();
   }
 }

--- a/embedding/embedlite/embedthread/EmbedLiteViewThreadChild.cpp
+++ b/embedding/embedlite/embedthread/EmbedLiteViewThreadChild.cpp
@@ -915,8 +915,11 @@ EmbedLiteViewThreadChild::RecvInputDataTouchMoveEvent(const ScrollableLayerGuid&
 }
 
 NS_IMETHODIMP
-EmbedLiteViewThreadChild::OnLocationChanged(const char* aLocation, bool aCanGoBack, bool aCanGoForward)
+EmbedLiteViewThreadChild::OnLocationChanged(const char* aLocation, bool aCanGoBack, bool aCanGoForward, bool aIsSameDocument)
 {
+  if (!aIsSameDocument) {
+    mHelper->mContentDocumentIsDisplayed = false;
+  }
   return SendOnLocationChanged(nsDependentCString(aLocation), aCanGoBack, aCanGoForward) ? NS_OK : NS_ERROR_FAILURE;
 }
 

--- a/embedding/embedlite/utils/WebBrowserChrome.cpp
+++ b/embedding/embedlite/utils/WebBrowserChrome.cpp
@@ -303,7 +303,9 @@ WebBrowserChrome::OnLocationChange(nsIWebProgress* aWebProgress,
   navigation->GetCanGoBack(&canGoBack);
   navigation->GetCanGoForward(&canGoForward);
 
-  mListener->OnLocationChanged(spec.get(), canGoBack, canGoForward);
+  bool isSameDocument = aFlags & nsIWebProgressListener::LOCATION_CHANGE_SAME_DOCUMENT;
+
+  mListener->OnLocationChanged(spec.get(), canGoBack, canGoForward, isSameDocument);
 
   // Keep track of hash changes
   mLocationHasChanged = slocation.Equals(mLastLocation);

--- a/embedding/embedlite/utils/nsIEmbedBrowserChromeListener.idl
+++ b/embedding/embedlite/utils/nsIEmbedBrowserChromeListener.idl
@@ -17,7 +17,8 @@
 [scriptable, uuid(ff88f95e-48d9-11e2-bca5-6b3dfc3f4672)]
 interface nsIEmbedBrowserChromeListener
 {
-    void onLocationChanged(in string aLocation, in boolean aCanGoBack, in boolean aCanGoForward);
+    void onLocationChanged(in string aLocation, in boolean aCanGoBack,
+                           in boolean aCanGoForward, in boolean aIsSameDocument);
     void onLoadStarted(in string aLocation);
     void onLoadFinished();
     void onLoadRedirect();


### PR DESCRIPTION
Otherwise the engine keeps recalculating viewport of a reloading web page for every META tag it meets. And may end up with a wrong viewport if correct frame metrics get clobbered by outdated data from earlier iterations.
