### PR TITLE
[pref] Drop unused preference from embedding.js

### DIFF
--- a/embedding/embedlite/embedding.js
+++ b/embedding/embedlite/embedding.js
@@ -298,7 +298,6 @@ pref("media.preload.auto", 2);    // preload metadata if preload=auto
 // optimize images memory usage
 pref("image.mem.decodeondraw", true);
 pref("image.mem.allow_locking_in_content_processes", false);
-pref("image.mem.min_discard_timeout_ms", 10000);
 pref("image.onload.decode.limit", 24); /* don't decode more than 24 images eagerly */
 
 // SimplePush


### PR DESCRIPTION
The code used the removed pref was deleted in
https://bugzilla.mozilla.org/show_bug.cgi?id=1104622
