### PR TITLE
EmbedLite: Fix build with accessibility enabled.

### DIFF
--- a/embedding/embedlite/utils/EmbedLiteXulAppInfo.cpp
+++ b/embedding/embedlite/utils/EmbedLiteXulAppInfo.cpp
@@ -15,6 +15,10 @@
 #include "nsStringGlue.h"
 #include "EmbedLiteAppThreadChild.h"
 
+#if defined(ACCESSIBILITY)
+#include "nsAccessibilityService.h"
+#endif
+
 using namespace mozilla::embedlite;
 
 EmbedLiteXulAppInfo::EmbedLiteXulAppInfo()


### PR DESCRIPTION
EmbedLiteXulAppInfo.cpp uses GetAccService() function without including
the actual header file defining it. This fixes the problem, making the
code buildable once again.
