### PR TITLE
[xulrunner] Add screen rotation API

### DIFF
--- a/embedding/embedlite/EmbedLiteView.cpp
+++ b/embedding/embedlite/EmbedLiteView.cpp
@@ -216,6 +216,13 @@ EmbedLiteView::SetGLViewPortSize(int width, int height)
 }
 
 void
+EmbedLiteView::SetScreenRotation(mozilla::ScreenRotation rotation)
+{
+  NS_ENSURE_TRUE(mViewImpl, );
+  mViewImpl->SetScreenRotation(rotation);
+}
+
+void
 EmbedLiteView::SuspendRendering()
 {
   NS_ENSURE_TRUE(mViewImpl, );

--- a/embedding/embedlite/EmbedLiteView.h
+++ b/embedding/embedlite/EmbedLiteView.h
@@ -7,6 +7,7 @@
 #define MOZ_VIEW_EMBED_H
 
 #include "mozilla/RefPtr.h"
+#include "mozilla/WidgetUtils.h"
 #include "nsStringGlue.h"
 #include "gfxMatrix.h"
 #include "nsRect.h"
@@ -113,6 +114,9 @@ public:
 
   //   Setup renderable GL/EGL window surface size
   virtual void SetGLViewPortSize(int width, int height);
+
+  // Set screen rotation (orientation change).
+  virtual void SetScreenRotation(mozilla::ScreenRotation rotation);
 
   // Scripting Interface, allow to extend embedding API by creating
   // child js scripts and messaging interface.

--- a/embedding/embedlite/embedshared/EmbedLiteViewBaseParent.cpp
+++ b/embedding/embedlite/embedshared/EmbedLiteViewBaseParent.cpp
@@ -29,6 +29,8 @@ EmbedLiteViewBaseParent::EmbedLiteViewBaseParent(const uint32_t& id, const uint3
   : mId(id)
   , mViewAPIDestroyed(false)
   , mCompositor(nullptr)
+  , mRotation(ROTATION_0)
+  , mPendingRotation(false)
   , mUILoop(MessageLoop::current())
   , mLastIMEState(0)
   , mUploadTexture(0)
@@ -65,6 +67,10 @@ EmbedLiteViewBaseParent::SetCompositor(EmbedLiteCompositorParent* aCompositor)
   mCompositor = aCompositor;
   UpdateScrollController();
   if (mCompositor) {
+    if (mPendingRotation) {
+      mCompositor->SetScreenRotation(mRotation, mWorldTransform);
+      mPendingRotation = false;
+    }
     mCompositor->SetSurfaceSize(mGLViewPortSize.width, mGLViewPortSize.height);
   }
 }
@@ -400,6 +406,19 @@ EmbedLiteViewBaseParent::SetGLViewPortSize(int width, int height)
   }
   unused << SendSetGLViewSize(mGLViewPortSize);
 
+  return NS_OK;
+}
+
+NS_IMETHODIMP
+EmbedLiteViewBaseParent::SetScreenRotation(const mozilla::ScreenRotation& rotation)
+{
+  mRotation = rotation;
+
+  if (mCompositor) {
+    mCompositor->SetScreenRotation(rotation);
+  } else {
+    mPendingRotation = true;
+  }
   return NS_OK;
 }
 

--- a/embedding/embedlite/embedshared/EmbedLiteViewBaseParent.h
+++ b/embedding/embedlite/embedshared/EmbedLiteViewBaseParent.h
@@ -7,6 +7,7 @@
 #define MOZ_VIEW_EMBED_BASE_PARENT_H
 
 #include "mozilla/embedlite/PEmbedLiteViewParent.h"
+#include "mozilla/WidgetUtils.h"
 #include "EmbedLiteViewIface.h"
 #include "GLDefs.h"
 
@@ -122,6 +123,11 @@ private:
 
   ScreenIntSize mViewSize;
   gfxSize mGLViewPortSize;
+
+  // Cache initial values.
+  mozilla::ScreenRotation mRotation;
+  bool mPendingRotation;
+
   MessageLoop* mUILoop;
   int mLastIMEState;
 

--- a/embedding/embedlite/embedshared/EmbedLiteViewIface.idl
+++ b/embedding/embedlite/embedshared/EmbedLiteViewIface.idl
@@ -7,6 +7,7 @@
 
 %{C++
 #include "mozilla/gfx/Matrix.h"
+#include "mozilla/WidgetUtils.h"
 #include "gfxRect.h"
 #include "InputData.h"
 #include "EmbedLiteView.h"
@@ -18,6 +19,7 @@ class nsString;
 %}
 [ref] native nsStringTArrayRef(nsTArray<nsString>);
 [ref] native gfxMatrix(mozilla::gfx::Matrix);
+[ref] native ScreenRotation(mozilla::ScreenRotation);
 [ref] native gfxRect(gfxRect);
 [ref] native nsIntPoint(nsIntPoint);
 [ref] native nsIntRect(nsIntRect);
@@ -32,6 +34,7 @@ interface EmbedLiteViewIface
     void RenderToImage(in buffer aData, in int32_t aWidth, in int32_t aHeigth, in int32_t aStride, in int32_t aDepth);
     void SetViewSize(in int32_t aWidth, in int32_t aHeight);
     void SetGLViewPortSize(in int32_t aWidth, in int32_t aHeight);
+    void SetScreenRotation([const] in ScreenRotation rotation);
     void ReceiveInputEvent([const] in InputData aEvent);
     void TextEvent(in string aComposite, in string aPreEdit);
     void SendKeyPress(in int32_t aDomKeyCode, in int32_t aModifiers, in int32_t aCharCode);

--- a/embedding/embedlite/embedthread/EmbedLiteCompositorParent.cpp
+++ b/embedding/embedlite/embedthread/EmbedLiteCompositorParent.cpp
@@ -17,6 +17,8 @@
 #include "gfxUtils.h"
 #include "nsRefreshDriver.h"
 
+#include "math.h"
+
 #include "GLContext.h"                  // for GLContext
 #include "GLScreenBuffer.h"             // for GLScreenBuffer
 #include "SharedSurfaceEGL.h"           // for SurfaceFactory_EGLImage
@@ -40,6 +42,8 @@ EmbedLiteCompositorParent::EmbedLiteCompositorParent(nsIWidget* aWidget,
                                                      uint32_t id)
   : CompositorParent(aWidget, aRenderToEGLSurface, aSurfaceWidth, aSurfaceHeight)
   , mId(id)
+  , mRotation(ROTATION_0)
+  , mUseScreenRotation(false)
   , mCurrentCompositeTask(nullptr)
   , mLastViewSize(aSurfaceWidth, aSurfaceHeight)
   , mInitialPaintCount(0)
@@ -117,8 +121,18 @@ EmbedLiteCompositorParent::UpdateTransformState()
   const CompositorParent::LayerTreeState* state = CompositorParent::GetIndirectShadowTree(RootLayerTreeId());
   NS_ENSURE_TRUE(state && state->mLayerManager, );
 
-  GLContext* context = static_cast<CompositorOGL*>(state->mLayerManager->GetCompositor())->gl();
+
+  CompositorOGL *compositor = static_cast<CompositorOGL*>(state->mLayerManager->GetCompositor());
+  NS_ENSURE_TRUE(compositor, );
+
+  GLContext* context = compositor->gl();
   NS_ENSURE_TRUE(context, );
+
+  if (mUseScreenRotation) {
+    LOGNI("SetScreenRotation is not fully implemented");
+    // compositor->SetScreenRotation(mRotation);
+    // state->mLayerManager->SetWorldTransform(mWorldTransform);
+  }
 
   if (context->IsOffscreen() && context->OffscreenSize() != mLastViewSize) {
     context->ResizeOffscreen(mLastViewSize);
@@ -225,6 +239,38 @@ void EmbedLiteCompositorParent::SetSurfaceSize(int width, int height)
 {
   mLastViewSize.SizeTo(width, height);
   SetEGLSurfaceSize(width, height);
+}
+
+void EmbedLiteCompositorParent::SetScreenRotation(const mozilla::ScreenRotation &rotation)
+{
+  if (mRotation != rotation) {
+    gfx::Matrix rotationMartix;
+    switch (rotation) {
+    case mozilla::ROTATION_90:
+        // Pi / 2
+        rotationMartix.Rotate(M_PI_2l);
+        rotationMartix.Translate(0.0, -mLastViewSize.height);
+        break;
+    case mozilla::ROTATION_270:
+        // 3 / 2 * Pi
+        rotationMartix.Rotate(M_PI_2l * 3);
+        rotationMartix.Translate(-mLastViewSize.width, 0.0);
+        break;
+    case mozilla::ROTATION_180:
+        // Pi
+        rotationMartix.Rotate(M_PIl);
+        rotationMartix.Translate(-mLastViewSize.width, -mLastViewSize.height);
+        break;
+    default:
+        break;
+    }
+
+    mWorldTransform = rotationMartix;
+    mRotation = rotation;
+    mUseScreenRotation = true;
+    CancelCurrentCompositeTask();
+    ScheduleRenderOnCompositorThread();
+  }
 }
 
 void*

--- a/embedding/embedlite/embedthread/EmbedLiteCompositorParent.h
+++ b/embedding/embedlite/embedthread/EmbedLiteCompositorParent.h
@@ -8,6 +8,7 @@
 
 #define COMPOSITOR_PERFORMANCE_WARNING
 
+#include "mozilla/WidgetUtils.h"
 #include "mozilla/layers/CompositorParent.h"
 #include "mozilla/layers/CompositorChild.h"
 #include "Layers.h"
@@ -26,6 +27,7 @@ public:
 
   bool RenderToContext(gfx::DrawTarget* aTarget);
   void SetSurfaceSize(int width, int height);
+  void SetScreenRotation(const mozilla::ScreenRotation& rotation);
   void* GetPlatformImage(int* width, int* height);
   virtual void SuspendRendering();
   virtual void ResumeRendering();
@@ -46,6 +48,9 @@ private:
   bool RenderGL();
 
   uint32_t mId;
+  gfx::Matrix mWorldTransform;
+  mozilla::ScreenRotation mRotation;
+  bool mUseScreenRotation;
   CancelableTask* mCurrentCompositeTask;
   gfx::IntSize mLastViewSize;
   short mInitialPaintCount;


### PR DESCRIPTION
Calculate the rotation matrix in EmbedLiteCompositorParent.

JB#27561

Not functional but allows https://github.com/tmeshkova/qtmozembed/pull/123 to be compiled against latest embedlite.

Includes both https://github.com/nemomobile-packages/gecko-dev/pull/9 and https://github.com/nemomobile-packages/gecko-dev/pull/10
