### PR TITLE
[embedlite] Add RequestGLContext back to EmbedLitePuppetWidget (esr)

### DIFF
--- a/embedding/embedlite/embedthread/EmbedLiteCompositorParent.cpp
+++ b/embedding/embedlite/embedthread/EmbedLiteCompositorParent.cpp
@@ -304,6 +304,12 @@ void EmbedLiteCompositorParent::DrawWindowOverlay(LayerManagerComposite *aManage
   }
 }
 
+bool EmbedLiteCompositorParent::RequestGLContext()
+{
+  EmbedLiteView* view = EmbedLiteApp::GetInstance()->GetViewByID(mId);
+  return view ? view->GetListener()->RequestCurrentGLContext() : false;
+}
+
 } // namespace embedlite
 } // namespace mozilla
 

--- a/embedding/embedlite/embedthread/EmbedLiteCompositorParent.h
+++ b/embedding/embedlite/embedthread/EmbedLiteCompositorParent.h
@@ -38,6 +38,8 @@ public:
   virtual void SuspendRendering();
   virtual void ResumeRendering();
 
+  virtual bool RequestGLContext();
+
   void DrawWindowUnderlay(mozilla::layers::LayerManagerComposite *aManager, nsIntRect aRect);
   void DrawWindowOverlay(mozilla::layers::LayerManagerComposite *aManager, nsIntRect aRect);
 

--- a/embedding/embedlite/embedthread/EmbedLitePuppetWidget.cpp
+++ b/embedding/embedlite/embedthread/EmbedLitePuppetWidget.cpp
@@ -566,7 +566,9 @@ EmbedLitePuppetWidget::GetNaturalBounds()
 bool
 EmbedLitePuppetWidget::HasGLContext()
 {
-  return true;
+  EmbedLiteCompositorParent* parent =
+    static_cast<EmbedLiteCompositorParent*>(mCompositorParent.get());
+  return parent->RequestGLContext();
 }
 
 void


### PR DESCRIPTION
This gives higher layer in the stack a possibility to customize gl context creation.

See also nemo-packages: https://github.com/nemomobile-packages/gecko-dev/pull/5
