### PR TITLE
[embedlite] Update last compose time in compositor. JB#28854

### DIFF
--- a/embedding/embedlite/embedthread/EmbedLiteCompositorParent.h
+++ b/embedding/embedlite/embedthread/EmbedLiteCompositorParent.h
@@ -43,7 +43,7 @@ protected:
 private:
   bool Invalidate();
   void UpdateTransformState();
-  bool RenderGL();
+  bool RenderGL(TimeStamp aScheduleTime);
 
   uint32_t mId;
   CancelableTask* mCurrentCompositeTask;


### PR DESCRIPTION
AsyncPanZoomController::UpdateAnimation() relies on the fact that the current sample's timestamp always differs from the previous one. In order to achieve that the time stamp needs to be updated in CompositorParent. B2G implementation does that in CompositorParent::CompositeCallback() which is not used in embedlite. Embedlite's analogue of CompositorParent::CompositeCallback() is EmbedLiteCompositorParent::RenderGL().
