### PR TITLE
[embedlite] Update last compose time in compositor. JB#28854

### DIFF
--- a/embedding/embedlite/embedthread/EmbedLiteCompositorParent.cpp
+++ b/embedding/embedlite/embedthread/EmbedLiteCompositorParent.cpp
@@ -164,7 +164,10 @@ EmbedLiteCompositorParent::Invalidate()
   UpdateTransformState();
 
   if (view->GetListener() && !view->GetListener()->Invalidate()) {
-    mCurrentCompositeTask = NewRunnableMethod(this, &EmbedLiteCompositorParent::RenderGL);
+    // Replace CompositorParent::CompositeCallback with EmbedLiteCompositorParent::RenderGL
+    // in mCurrentCompositeTask (NB: actually EmbedLiteCompositorParent::mCurrentCompositorParent
+    // overshadows CompositorParent::mCurrentCompositorTask. Beware!).
+    mCurrentCompositeTask = NewRunnableMethod(this, &EmbedLiteCompositorParent::RenderGL, TimeStamp::Now());
     MessageLoop::current()->PostDelayedTask(FROM_HERE, mCurrentCompositeTask, sDefaultPaintInterval);
     return true;
   }
@@ -188,8 +191,9 @@ bool EmbedLiteCompositorParent::RenderToContext(gfx::DrawTarget* aTarget)
   return true;
 }
 
-bool EmbedLiteCompositorParent::RenderGL()
+bool EmbedLiteCompositorParent::RenderGL(TimeStamp aScheduleTime)
 {
+  mLastCompose = aScheduleTime;
   if (mCurrentCompositeTask) {
     mCurrentCompositeTask->Cancel();
     mCurrentCompositeTask = nullptr;

--- a/embedding/embedlite/embedthread/EmbedLiteCompositorParent.h
+++ b/embedding/embedlite/embedthread/EmbedLiteCompositorParent.h
@@ -55,7 +55,7 @@ protected:
 private:
   bool Invalidate();
   void UpdateTransformState();
-  bool RenderGL();
+  bool RenderGL(TimeStamp aScheduleTime);
 
   uint32_t mId;
   gfx::Matrix mWorldTransform;


### PR DESCRIPTION
AsyncPanZoomController::UpdateAnimation() relies on the fact that the current sample's timestamp always differs from the previous one. In order to achieve that the time stamp needs to be updated in CompositorParent. B2G implementation does that in CompositorParent::CompositeCallback() which is not used in embedlite. Embedlite's analogue of CompositorParent::CompositeCallback() is EmbedLiteCompositorParent::RenderGL().
