### PR TITLE
Make sure system sqlite library is used for mer builds.

### DIFF
--- a/embedding/embedlite/config/mozconfig.merqtxulrunner
+++ b/embedding/embedlite/config/mozconfig.merqtxulrunner
@@ -13,6 +13,7 @@ export CXXFLAGS="$CXXFLAGS -DUSE_ANDROID_OMTC_HACKS=1 "
 ac_add_options --prefix=/usr
 
 ac_add_options --with-system-jpeg
+ac_add_options --enable-system-sqlite
 
 ac_add_options --with-gl-provider=EGL
 


### PR DESCRIPTION
This synchronizes mer config files with the one actually used in
deployment by Mer/SailfishOS.
