### PR TITLE
Add possobility to set URL for initial view content. JB#27745

### DIFF
--- a/embedding/embedlite/embedding.js
+++ b/embedding/embedlite/embedding.js
@@ -316,3 +316,7 @@ pref("full-screen-api.content-only", true);
 // the window, the window size doesn't change. This pref has no effect when
 // running in actual Metro mode, as the widget will already be fullscreen then.
 pref("full-screen-api.ignore-widgets", true);
+
+// URL for content loaded initnially into the view after it's created. The URL
+// won't be added to browsing history.
+pref("browser.newtab.url", "about:blank");

--- a/embedding/embedlite/embedthread/EmbedLiteViewThreadChild.cpp
+++ b/embedding/embedlite/embedthread/EmbedLiteViewThreadChild.cpp
@@ -252,6 +252,14 @@ EmbedLiteViewThreadChild::InitGeckoWindow(const uint32_t& parentId, const bool& 
     NS_ERROR("SetVisibility failed.\n");
   }
 
+  nsAutoCString initialUrl;
+  rv = Preferences::GetDefaultCString("browser.newtab.url", &initialUrl);
+  if (NS_SUCCEEDED(rv) && !initialUrl.IsEmpty()) {
+    mWebNavigation->LoadURI(NS_ConvertUTF8toUTF16(initialUrl).get(),
+                            nsIWebNavigation::LOAD_FLAGS_BYPASS_HISTORY,
+                            0, 0, 0);
+  }
+
   mHelper = new TabChildHelper(this);
   unused << SendInitialized();
 }


### PR DESCRIPTION
Currently when view the is created it does not have any content by default.
The embedder is responsible for manually settings the initial content by
EmbedLiteView::LoadURL. The current setup has two major problems.
1. Until the content is loaded into the view and the PresShell::Paint is
   called the view contents will basically be invalid. In most cases
   the initial content loaded by the embedder will be some web page
   fetched from remote server. The PresShell::Paint will be invoked after
   such content is loaded and initial reflow of the document is
   finished. Since many todays web pages are quite complex the time
   between view creation and first paint operation can easily reach a
   couple of seconds. During this time the user will only see invalid
   content.
2. The current implementation of EmbedLiteView::LoadURL does not allow
   the embedder to customize URL loading behaviour. In case of the issue
   this patch tries to address it's not possible to tell the engine to
   don't add the URL into browsing history.

The patch attempts to fix the issue by following firefox behaviour. In
firefox desktop and android browsers newly created views always display a
predefined local page that can be painted in a matter of miliseconds. This
feature is actually used to implement firefox speeddial page.

The user can customize new tab default page through browser.newtab.url
preference. By default about:blank page is used.
