### PR TITLE
[embedlite] Don't override embedlite's nsDownloadManagerUI

### DIFF
--- a/toolkit/components/downloads/moz.build
+++ b/toolkit/components/downloads/moz.build
@@ -60,7 +60,7 @@ if CONFIG['OS_ARCH'] == 'WINNT':
 
 # XXX - Until Suite builds off XULRunner we can't guarantee our implementation
 # of nsIDownloadManagerUI overrides toolkit's.
-if not CONFIG['MOZ_SUITE']:
+if False:
     EXTRA_COMPONENTS += [
         'nsDownloadManagerUI.js',
         'nsDownloadManagerUI.manifest',


### PR DESCRIPTION
Currently the default implementation of nsDownloadManagerUI overrides the one defined in embedlite-components thus the download manager fails to initialize.

Probably this should be something

> -if not CONFIG['MOZ_SUITE']:
> +if not CONFIG['MOZ_SUITE'] and not CONFIG['MOZ_EMBEDLITE']:

but as we don't have such variable the condition is just disabled.
