### PR TITLE
[embedlite] Check presence of event handler before using it

### DIFF
--- a/embedding/embedlite/utils/WebBrowserChrome.cpp
+++ b/embedding/embedlite/utils/WebBrowserChrome.cpp
@@ -571,8 +571,10 @@ NS_IMETHODIMP WebBrowserChrome::GetTitle(char16_t** aTitle)
 NS_IMETHODIMP WebBrowserChrome::SetTitle(const char16_t* aTitle)
 {
   // Store local title
-  mTitle = aTitle;
-  mListener->OnTitleChanged(mTitle.get());
+  mTitle.Assign(nsDependentString(aTitle));
+  if (mListener) {
+      mListener->OnTitleChanged(mTitle.get());
+  }
   return NS_OK;
 }
 


### PR DESCRIPTION
It might happen that a web view is requested to be closed programattically
from JavaScript, but not closed yet. During this time frame event handler
is NULL already and can't be used.
