### PR TITLE
Use Pause/Resume methods from CompositorParent. JB#29532

### DIFF
--- a/embedding/embedlite/embedthread/EmbedLiteCompositorParent.cpp
+++ b/embedding/embedlite/embedthread/EmbedLiteCompositorParent.cpp
@@ -308,29 +308,13 @@ EmbedLiteCompositorParent::GetPlatformImage(int* width, int* height)
 void
 EmbedLiteCompositorParent::SuspendRendering()
 {
-  if (!CompositorParent::IsInCompositorThread()) {
-    CancelableTask* pauseTask = NewRunnableMethod(this, &EmbedLiteCompositorParent::SuspendRendering);
-    CompositorLoop()->PostTask(FROM_HERE, pauseTask);
-    return;
-  }
-
-  const CompositorParent::LayerTreeState* state = CompositorParent::GetIndirectShadowTree(RootLayerTreeId());
-  NS_ENSURE_TRUE(state && state->mLayerManager, );
-  static_cast<CompositorOGL*>(state->mLayerManager->GetCompositor())->Pause();
+  CompositorParent::SchedulePauseOnCompositorThread();
 }
 
 void
 EmbedLiteCompositorParent::ResumeRendering()
 {
-  if (!CompositorParent::IsInCompositorThread()) {
-    CancelableTask* pauseTask = NewRunnableMethod(this, &EmbedLiteCompositorParent::ResumeRendering);
-    CompositorLoop()->PostTask(FROM_HERE, pauseTask);
-    return;
-  }
-
-  const CompositorParent::LayerTreeState* state = CompositorParent::GetIndirectShadowTree(RootLayerTreeId());
-  NS_ENSURE_TRUE(state && state->mLayerManager, );
-  static_cast<CompositorOGL*>(state->mLayerManager->GetCompositor())->Resume();
+  CompositorParent::ScheduleResumeOnCompositorThread(mLastViewSize.width, mLastViewSize.height);
 }
 
 bool EmbedLiteCompositorParent::RequestGLContext()


### PR DESCRIPTION
The CompositorParent's SchedulePauseOnCompositorThread and
ScheduleResumeOnCompositorThread serve exactly the same purpose as our
custom EmbedLiteCompositorParent::{Suspend|Pause}Rendering. There are
two important differences though.
1. Pause and resume methods from CompositorParent wait for the actual
   outcome of the operation.
2. CompositorParent's methods update the state of
   CompositorParent::mPaused value. Since the mPaused is used to
   influence the output from CompositorParent::CanComposite method it's
   rather critical we update this variable state correctly.
