### PR TITLE
Remove some unnecessary/dead code from TabChild.

### DIFF
--- a/embedding/embedlite/utils/TabChildHelper.cpp
+++ b/embedding/embedlite/utils/TabChildHelper.cpp
@@ -51,7 +51,6 @@ static bool sPostAZPCAsJsonViewport(false);
 
 TabChildHelper::TabChildHelper(EmbedLiteViewChildIface* aView)
   : mView(aView)
-  , mHasValidInnerSize(false)
 {
   LOGT();
 
@@ -199,12 +198,6 @@ TabChildHelper::InitTabChildGlobal()
   chromeHandler->AddEventListener(NS_LITERAL_STRING("scroll"), this, false);
 
   return true;
-}
-
-bool
-TabChildHelper::HasValidInnerSize()
-{
-  return mHasValidInnerSize;
 }
 
 NS_IMETHODIMP

--- a/embedding/embedlite/utils/TabChildHelper.h
+++ b/embedding/embedlite/utils/TabChildHelper.h
@@ -70,7 +70,6 @@ protected:
   bool ConvertMutiTouchInputToEvent(const mozilla::MultiTouchInput& aData,
                                     WidgetTouchEvent& aEvent);
   void CancelTapTracking();
-  bool HasValidInnerSize();
 
 private:
   bool InitTabChildGlobal();
@@ -82,8 +81,6 @@ private:
   friend class EmbedLiteViewChildIface;
   friend class EmbedLiteViewBaseChild;
   EmbedLiteViewChildIface* mView;
-  mozilla::layers::FrameMetrics mLastSubFrameMetrics;
-  bool mHasValidInnerSize;
 };
 
 }


### PR DESCRIPTION
1. The HasValidInnerSize function and mHasValidInnerSize variable are
   already defined in TabChild's base class. Since the purpose for both
   versions is exactly the same remove embedlite's unnecessary override.
2. The TabChild::mLastSubFrameMetrics is not used anywhere in the code.
