### PR TITLE
Revert "Remove some unnecessary/dead code from TabChild."

### DIFF
--- a/embedding/embedlite/utils/TabChildHelper.cpp
+++ b/embedding/embedlite/utils/TabChildHelper.cpp
@@ -51,6 +51,7 @@ static bool sPostAZPCAsJsonViewport(false);
 
 TabChildHelper::TabChildHelper(EmbedLiteViewChildIface* aView)
   : mView(aView)
+  , mHasValidInnerSize(false)
 {
   LOGT();
 
@@ -198,6 +199,12 @@ TabChildHelper::InitTabChildGlobal()
   chromeHandler->AddEventListener(NS_LITERAL_STRING("scroll"), this, false);
 
   return true;
+}
+
+bool
+TabChildHelper::HasValidInnerSize()
+{
+  return mHasValidInnerSize;
 }
 
 NS_IMETHODIMP

--- a/embedding/embedlite/utils/TabChildHelper.h
+++ b/embedding/embedlite/utils/TabChildHelper.h
@@ -70,6 +70,7 @@ protected:
   bool ConvertMutiTouchInputToEvent(const mozilla::MultiTouchInput& aData,
                                     WidgetTouchEvent& aEvent);
   void CancelTapTracking();
+  bool HasValidInnerSize();
 
 private:
   bool InitTabChildGlobal();
@@ -81,6 +82,7 @@ private:
   friend class EmbedLiteViewChildIface;
   friend class EmbedLiteViewBaseChild;
   EmbedLiteViewChildIface* mView;
+  bool mHasValidInnerSize;
 };
 
 }


### PR DESCRIPTION
The commit was not actually suitable for v38. It seems the
HasValidInnerSize function was moved from TabChildBase to TabChild
somewhere between v32 and v38.

This reverts commit a4eddcda225cac90fe53e4077a7413f1c563b4d6.
