### PR TITLE
[Mer] Switch to gstreamr 1.0

### DIFF
--- a/embedding/embedlite/config/mozconfig.merqtxulrunner
+++ b/embedding/embedlite/config/mozconfig.merqtxulrunner
@@ -35,7 +35,7 @@ ac_add_options --disable-printing
 # disabling for now, since the build fails...
 ac_add_options --enable-webrtc
 ac_add_options --enable-profiling
-ac_add_options --enable-gstreamer
+ac_add_options --enable-gstreamer=1.0
 ac_add_options --disable-dbus
 ac_add_options --disable-necko-wifi
 ac_add_options --disable-elf-hack


### PR DESCRIPTION
This is what SailfishOS/Mer currently use. It's already the default
version in currently used embedlite_31 version. Since embedlite_38 does
also seem to work fine with gstreamer 1.0 (tested on youtube.com) lets
switch to it.
