### PR TITLE
[embedlite] Expose an API for clearing gecko compositing surface. JB#29995

### DIFF
--- a/embedding/embedlite/EmbedLiteView.cpp
+++ b/embedding/embedlite/EmbedLiteView.cpp
@@ -303,6 +303,13 @@ EmbedLiteView::ScheduleUpdate()
 }
 
 void
+EmbedLiteView::ClearContent(uint8_t r, uint8_t g, uint8_t b, uint8_t a)
+{
+  NS_ENSURE_TRUE(mViewImpl, );
+  mViewImpl->ClearContent(NS_RGBA(r, g, b, a));
+}
+
+void
 EmbedLiteView::SuspendRendering()
 {
   NS_ENSURE_TRUE(mViewImpl, );

--- a/embedding/embedlite/EmbedLiteView.h
+++ b/embedding/embedlite/EmbedLiteView.h
@@ -127,6 +127,10 @@ public:
   // Set screen rotation (orientation change).
   virtual void SetScreenRotation(mozilla::ScreenRotation rotation);
   virtual void ScheduleUpdate();
+  // Clear the content of the view compositing surface with a given color.
+  // Calling the function before the view has created it's compositor
+  // (EmbedLiteViewListener::RequestCurrentGLContext was called) is a no-op.
+  virtual void ClearContent(uint8_t r, uint8_t g, uint8_t b, uint8_t a);
 
   // Scripting Interface, allow to extend embedding API by creating
   // child js scripts and messaging interface.

--- a/embedding/embedlite/embedshared/EmbedLiteViewBaseParent.cpp
+++ b/embedding/embedlite/embedshared/EmbedLiteViewBaseParent.cpp
@@ -18,7 +18,6 @@
 
 using namespace mozilla::gfx;
 using namespace mozilla::gl;
-
 using namespace mozilla::layers;
 using namespace mozilla::widget;
 
@@ -448,6 +447,15 @@ EmbedLiteViewBaseParent::SuspendRendering()
     mCompositor->SuspendRendering();
   }
 
+  return NS_OK;
+}
+
+NS_IMETHODIMP
+EmbedLiteViewBaseParent::ClearContent(nscolor color)
+{
+  if (mCompositor) {
+    mCompositor->ClearCompositorSurface(color);
+  }
   return NS_OK;
 }
 

--- a/embedding/embedlite/embedshared/EmbedLiteViewIface.idl
+++ b/embedding/embedlite/embedshared/EmbedLiteViewIface.idl
@@ -28,7 +28,7 @@ class nsString;
 [ptr] native buffer(unsigned char);
 [ptr] native EmbedLiteView(mozilla::embedlite::EmbedLiteView);
 
-[scriptable, uuid(6d7750f8-e028-4445-a0cb-d9ce28fb03dd)]
+[scriptable, uuid(9aab16e8-1992-11e5-b60b-1697f925ec7b)]
 interface EmbedLiteViewIface
 {
     void RenderToImage(in buffer aData, in int32_t aWidth, in int32_t aHeigth, in int32_t aStride, in int32_t aDepth);
@@ -50,4 +50,5 @@ interface EmbedLiteViewIface
     void SuspendRendering();
     void ResumeRendering();
     void SetEmbedAPIView(in EmbedLiteView aView);
+    void ClearContent(in uint32_t aColor);
 };

--- a/embedding/embedlite/embedthread/EmbedLiteCompositorParent.cpp
+++ b/embedding/embedlite/embedthread/EmbedLiteCompositorParent.cpp
@@ -339,6 +339,34 @@ void EmbedLiteCompositorParent::DrawWindowOverlay(LayerManagerComposite *aManage
   }
 }
 
+void EmbedLiteCompositorParent::ClearCompositorSurface(nscolor aColor)
+{
+  CancelCurrentCompositeTask();
+  const CompositorParent::LayerTreeState* state = GetIndirectShadowTree(RootLayerTreeId());
+  MOZ_ASSERT(state && state->mLayerManager);
+  GLContext* context = static_cast<CompositorOGL*>(state->mLayerManager->GetCompositor())->gl();
+  if (context) {
+    CompositorLoop()->PostTask(FROM_HERE, NewRunnableFunction(&ClearCompositorSurfaceImpl, context, aColor));
+  } else {
+    NS_WARNING("Trying to clear content of compositor without GL context!");
+  }
+}
+
+void EmbedLiteCompositorParent::ClearCompositorSurfaceImpl(GLContext* aContext, nscolor aColor)
+{
+  MOZ_ASSERT(CompositorParent::IsInCompositorThread());
+  if (aContext->MakeCurrent()) {
+    LOGT("color: %x", aColor);
+    float r = NS_GET_R(aColor) / 255;
+    float g = NS_GET_G(aColor) / 255;
+    float b = NS_GET_B(aColor) / 255;
+    float a = NS_GET_A(aColor) / 255;
+    aContext->fClearColor(r, g, b, a);
+    aContext->fClear(LOCAL_GL_COLOR_BUFFER_BIT | LOCAL_GL_DEPTH_BUFFER_BIT);
+    aContext->SwapBuffers();
+  }
+}
+
 } // namespace embedlite
 } // namespace mozilla
 

--- a/embedding/embedlite/embedthread/EmbedLiteCompositorParent.h
+++ b/embedding/embedlite/embedthread/EmbedLiteCompositorParent.h
@@ -16,6 +16,9 @@
 
 namespace mozilla {
 
+namespace gl {
+class GLContext;
+}
 namespace layers {
 class LayerManagerComposite;
 }
@@ -34,13 +37,13 @@ public:
   void SetSurfaceSize(int width, int height);
   void SetScreenRotation(const mozilla::ScreenRotation& rotation);
   void* GetPlatformImage(int* width, int* height);
-  virtual void SuspendRendering();
-  virtual void ResumeRendering();
-
-  virtual bool RequestGLContext();
+  void SuspendRendering();
+  void ResumeRendering();
+  bool RequestGLContext();
 
   void DrawWindowUnderlay(mozilla::layers::LayerManagerComposite *aManager, nsIntRect aRect);
   void DrawWindowOverlay(mozilla::layers::LayerManagerComposite *aManager, nsIntRect aRect);
+  void ClearCompositorSurface(nscolor);
 
 protected:
   virtual ~EmbedLiteCompositorParent();
@@ -56,6 +59,8 @@ private:
   bool Invalidate();
   void UpdateTransformState();
   bool RenderGL(TimeStamp aScheduleTime);
+
+  static void ClearCompositorSurfaceImpl(mozilla::gl::GLContext*, nscolor);
 
   uint32_t mId;
   gfx::Matrix mWorldTransform;


### PR DESCRIPTION
In new sailfish-browser rendering architecture when all the tabs share
the same compositing surface we need the ability to clear it in cerain
cases. One example is when all the tabs get closed. By default this
would mean that the content of the last rendered active page will ocupy
the compositing surface until a new tab is created and some page is
loaded into it. This is rather bad from user experience POV. The problem
could theoretically be solved by clearing the surface on the browser
side, but since gecko draws to it from a dedicated compositor thread it
would require an additional synchronization mechanism to be introduced.

This patch takes a simplier approach by introducing a dedicated API for
clearing view compositing surface with a given color. This should allow
any application to clear the compositing surface whenever it wants
provided the compositor for the view has been initialized. The function
will execute necessary GL commands on an appropriate gecko thread.
