### PR TITLE
[xulrunner] Generalize and improve external gl context handling. Contributes to JB#30162

### DIFF
--- a/embedding/embedlite/embedding.js
+++ b/embedding/embedlite/embedding.js
@@ -113,6 +113,10 @@ pref("embedlite.azpc.json.longtap", false);
 pref("embedlite.azpc.json.scroll", false);
 // Make gecko compositor use GL context/surface provided by the application.
 pref("embedlite.compositor.external_gl_context", false);
+// Request the application to create GLContext for the compositor as
+// soon as the top level PuppetWidget is creted for the view. Setting
+// this pref only makes sense when using external compositor gl context.
+pref("embedlite.compositor.request_external_gl_context_early", false);
 pref("extensions.update.enabled", false);
 pref("toolkit.storage.synchronous", 0);
 /* new html5 forms */

--- a/embedding/embedlite/embedding.js
+++ b/embedding/embedlite/embedding.js
@@ -111,6 +111,8 @@ pref("embedlite.azpc.json.singletap", false);
 pref("embedlite.azpc.json.doubletap", false);
 pref("embedlite.azpc.json.longtap", false);
 pref("embedlite.azpc.json.scroll", false);
+// Make gecko compositor use GL context/surface provided by the application.
+pref("embedlite.compositor.external_gl_context", false);
 pref("extensions.update.enabled", false);
 pref("toolkit.storage.synchronous", 0);
 /* new html5 forms */

--- a/embedding/embedlite/embedshared/EmbedLitePuppetWidget.h
+++ b/embedding/embedlite/embedshared/EmbedLitePuppetWidget.h
@@ -172,6 +172,7 @@ private:
   nsresult Paint();
   bool ViewIsValid();
   mozilla::gl::GLContext* GetGLContext() const;
+  static void CreateGLContextEarly(uint32_t aViewId);
 
   EmbedLitePuppetWidget* TopWindow();
   bool IsTopLevel();

--- a/embedding/embedlite/embedshared/EmbedLitePuppetWidget.h
+++ b/embedding/embedlite/embedshared/EmbedLitePuppetWidget.h
@@ -145,7 +145,6 @@ public:
   virtual void CreateCompositor(int aWidth, int aHeight);
   virtual void CreateCompositor();
   virtual nsIntRect GetNaturalBounds();
-  virtual bool HasGLContext();
 
   /**
    * Called before the LayerManager draws the layer tree.
@@ -172,6 +171,7 @@ protected:
 private:
   nsresult Paint();
   bool ViewIsValid();
+  mozilla::gl::GLContext* GetGLContext() const;
 
   EmbedLitePuppetWidget* TopWindow();
   bool IsTopLevel();

--- a/embedding/embedlite/embedthread/EmbedLiteCompositorParent.cpp
+++ b/embedding/embedlite/embedthread/EmbedLiteCompositorParent.cpp
@@ -317,12 +317,6 @@ EmbedLiteCompositorParent::ResumeRendering()
   CompositorParent::ScheduleResumeOnCompositorThread(mLastViewSize.width, mLastViewSize.height);
 }
 
-bool EmbedLiteCompositorParent::RequestGLContext()
-{
-  EmbedLiteView* view = EmbedLiteApp::GetInstance()->GetViewByID(mId);
-  return view ? view->GetListener()->RequestCurrentGLContext() : false;
-}
-
 void EmbedLiteCompositorParent::DrawWindowUnderlay(LayerManagerComposite *aManager, nsIntRect aRect)
 {
   EmbedLiteView* view = EmbedLiteApp::GetInstance()->GetViewByID(mId);

--- a/embedding/embedlite/embedthread/EmbedLiteCompositorParent.h
+++ b/embedding/embedlite/embedthread/EmbedLiteCompositorParent.h
@@ -37,8 +37,6 @@ public:
   virtual void SuspendRendering();
   virtual void ResumeRendering();
 
-  virtual bool RequestGLContext();
-
   void DrawWindowUnderlay(mozilla::layers::LayerManagerComposite *aManager, nsIntRect aRect);
   void DrawWindowOverlay(mozilla::layers::LayerManagerComposite *aManager, nsIntRect aRect);
 


### PR DESCRIPTION
See https://github.com/nemomobile-packages/gecko-dev/pull/31 for details regarding the patchset. With this in place it should be possible to use gecko 38 build with upstream sailfish-browser from next branch.
