### PR TITLE
[embedlite] Enable meta viewport support.

### DIFF
--- a/embedding/embedlite/embedding.js
+++ b/embedding/embedlite/embedding.js
@@ -1,4 +1,5 @@
 pref("dom.w3c_touch_events.enabled", 1);
+pref("dom.meta-viewport.enabled", true);
 pref("plugins.force.wmode", "opaque");
 pref("browser.xul.error_pages.enabled", true);
 pref("nglayout.debug.paint_flashing", false);


### PR DESCRIPTION
The pref was added somewhere between v31 and v38. It's enabled by
default on b2g and fennect. The code that the feature controls was
enabled by default in enbedlite_31. Without meta viewport support most
mobile pages are broken and multitouch gestures don't work.
