### PR TITLE
[embedlite] Trigger tile size computation from EmbedLitePuppetWidget:Create

### DIFF
--- a/embedding/embedlite/embedshared/EmbedLitePuppetWidget.cpp
+++ b/embedding/embedlite/embedshared/EmbedLitePuppetWidget.cpp
@@ -164,6 +164,8 @@ EmbedLitePuppetWidget::Create(nsIWidget*        aParent,
         NewRunnableFunction(&CreateGLContextEarly, mId));
   }
 
+  gfxPlatform::GetPlatform()->ComputeTileSize();
+
   return NS_OK;
 }
 


### PR DESCRIPTION
In generic gecko the gfxPlatform::ComputeTileSize is called when
CompositorParent instance is created. In embedlite this happens pretty
late and what is worse the process races with RefreshDriverTimer. In
rare cases reflow triggered from the refresh timer can try to access
time size before CompositorParent has been created. In such case we'll
crash due to an assert. Ex:

0  gfxPlatform::GetTileWidth (this=0xe31ac820) at gfx/thebes/gfxPlatform.cpp:991
1  GetDisplayPortFromMarginsData (aContent=0xe1003280, aMarginsData=0xe1014600, aMultiplier=2) at layout/base/nsLayoutUtils.cpp:903
2  GetDisplayPortImpl (aContent=0xe1003280, aResult=0xe8dfe6ac, aMultiplier=2) at layout/base/nsLayoutUtils.cpp:991
3  nsLayoutUtils::GetDisplayPort (aContent=0xe1003280, aResult=0xe8dfe6ac) at layout/base/nsLayoutUtils.cpp:1000
4  mozilla::ScrollFrameHelper::IsRectNearlyVisible (this=0xe3e03450, aRect=...) at layout/generic/nsGfxScrollFrame.cpp:3206
5  nsHTMLScrollFrame::IsRectNearlyVisible (this=0xe3e03400, aRect=...) at layout/generic/nsGfxScrollFrame.h:734
6  nsLayoutUtils::UpdateImageVisibilityForFrame (aImageFrame=0xe0e67bc0) at layout/base/nsLayoutUtils.cpp:7419
7  nsImageFrame::ReflowFinished (this=0xe0e67bc0) at layout/generic/nsImageFrame.cpp:965
8  PresShell::HandlePostedReflowCallbacks (this=0xea3e25e0, aInterruptible=true) at layout/base/nsPresShell.cpp:4152
9  PresShell::DidDoReflow (this=0xea3e25e0, aInterruptible=true, aWasInterrupted=false) layout/base/nsPresShell.cpp:9164
10 PresShell::ProcessReflowCommands (this=0xea3e25e0, aInterruptible=true) at layout/base/nsPresShell.cpp:9536
11 PresShell::FlushPendingNotifications (this=0xea3e25e0, aFlush=...) at layout/base/nsPresShell.cpp:4355
12 nsRefreshDriver::Tick (this=0xe4395a20, aNowEpoch=1436880581552719, aNowTime=...) at layout/base/nsRefreshDriver.cpp:1649
13 mozilla::RefreshDriverTimer::TickDriver (driver=0xe4395a20, jsnow=1436880581552719, now=...) at layout/base/nsRefreshDriver.cpp:198
