### PR TITLE
Add dummy GfxInfo implementation for non X11 qt platforms.

### DIFF
--- a/widget/qt/GfxInfo.cpp
+++ b/widget/qt/GfxInfo.cpp
@@ -1,0 +1,216 @@
+/* -*- Mode: C++; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "GfxInfo.h"
+
+using namespace mozilla::widget;
+
+/* GetD2DEnabled and GetDwriteEnabled shouldn't be called until after gfxPlatform initialization
+ * has occurred because they depend on it for information. (See bug 591561) */
+nsresult
+GfxInfo::GetD2DEnabled(bool *aEnabled)
+{
+  return NS_ERROR_FAILURE;
+}
+
+nsresult
+GfxInfo::GetDWriteEnabled(bool *aEnabled)
+{
+  return NS_ERROR_FAILURE;
+}
+
+/* readonly attribute DOMString DWriteVersion; */
+NS_IMETHODIMP
+GfxInfo::GetDWriteVersion(nsAString & aDwriteVersion)
+{
+  return NS_ERROR_FAILURE;
+}
+
+/* readonly attribute DOMString cleartypeParameters; */
+NS_IMETHODIMP
+GfxInfo::GetCleartypeParameters(nsAString & aCleartypeParams)
+{
+  return NS_ERROR_FAILURE;
+}
+
+/* readonly attribute DOMString adapterDescription; */
+NS_IMETHODIMP
+GfxInfo::GetAdapterDescription(nsAString & aAdapterDescription)
+{
+  aAdapterDescription.Truncate();
+  return NS_OK;
+}
+
+/* readonly attribute DOMString adapterDescription2; */
+NS_IMETHODIMP
+GfxInfo::GetAdapterDescription2(nsAString & aAdapterDescription)
+{
+  return NS_ERROR_FAILURE;
+}
+
+/* readonly attribute DOMString adapterRAM; */
+NS_IMETHODIMP
+GfxInfo::GetAdapterRAM(nsAString & aAdapterRAM)
+{
+  aAdapterRAM.Truncate();
+  return NS_OK;
+}
+
+/* readonly attribute DOMString adapterRAM2; */
+NS_IMETHODIMP
+GfxInfo::GetAdapterRAM2(nsAString & aAdapterRAM)
+{
+  return NS_ERROR_FAILURE;
+}
+
+/* readonly attribute DOMString adapterDriver; */
+NS_IMETHODIMP
+GfxInfo::GetAdapterDriver(nsAString & aAdapterDriver)
+{
+  aAdapterDriver.Truncate();
+  return NS_OK;
+}
+
+/* readonly attribute DOMString adapterDriver2; */
+NS_IMETHODIMP
+GfxInfo::GetAdapterDriver2(nsAString & aAdapterDriver)
+{
+  return NS_ERROR_FAILURE;
+}
+
+/* readonly attribute DOMString adapterDriverVersion; */
+NS_IMETHODIMP
+GfxInfo::GetAdapterDriverVersion(nsAString & aAdapterDriverVersion)
+{
+  aAdapterDriverVersion.Truncate();
+  return NS_OK;
+}
+
+/* readonly attribute DOMString adapterDriverVersion2; */
+NS_IMETHODIMP
+GfxInfo::GetAdapterDriverVersion2(nsAString & aAdapterDriverVersion)
+{
+  return NS_ERROR_FAILURE;
+}
+
+/* readonly attribute DOMString adapterDriverDate; */
+NS_IMETHODIMP
+GfxInfo::GetAdapterDriverDate(nsAString & aAdapterDriverDate)
+{
+  aAdapterDriverDate.Truncate();
+  return NS_OK;
+}
+
+/* readonly attribute DOMString adapterDriverDate2; */
+NS_IMETHODIMP
+GfxInfo::GetAdapterDriverDate2(nsAString & aAdapterDriverDate)
+{
+  return NS_ERROR_FAILURE;
+}
+
+/* readonly attribute DOMString adapterVendorID; */
+NS_IMETHODIMP
+GfxInfo::GetAdapterVendorID(nsAString & aAdapterVendorID)
+{
+  aAdapterVendorID.Truncate();
+  return NS_OK;
+}
+
+/* readonly attribute DOMString adapterVendorID2; */
+NS_IMETHODIMP
+GfxInfo::GetAdapterVendorID2(nsAString & aAdapterVendorID)
+{
+  return NS_ERROR_FAILURE;
+}
+
+/* readonly attribute DOMString adapterDeviceID; */
+NS_IMETHODIMP
+GfxInfo::GetAdapterDeviceID(nsAString & aAdapterDeviceID)
+{
+  aAdapterDeviceID.Truncate();
+  return NS_OK;
+}
+
+/* readonly attribute DOMString adapterDeviceID2; */
+NS_IMETHODIMP
+GfxInfo::GetAdapterDeviceID2(nsAString & aAdapterDeviceID)
+{
+  return NS_ERROR_FAILURE;
+}
+
+/* readonly attribute DOMString adapterSubsysID; */
+NS_IMETHODIMP
+GfxInfo::GetAdapterSubsysID(nsAString & aAdapterSubsysID)
+{
+  return NS_ERROR_FAILURE;
+}
+
+/* readonly attribute DOMString adapterSubsysID2; */
+NS_IMETHODIMP
+GfxInfo::GetAdapterSubsysID2(nsAString & aAdapterSubsysID)
+{
+  return NS_ERROR_FAILURE;
+}
+
+/* readonly attribute boolean isGPU2Active; */
+NS_IMETHODIMP
+GfxInfo::GetIsGPU2Active(bool* aIsGPU2Active)
+{
+  return NS_ERROR_FAILURE;
+}
+
+const nsTArray<GfxDriverInfo>&
+GfxInfo::GetGfxDriverInfo()
+{
+  return *mDriverInfo;
+}
+
+uint32_t GfxInfo::OperatingSystemVersion()
+{
+  return 0;
+}
+
+nsresult
+GfxInfo::GetFeatureStatusImpl(int32_t /*aFeature*/, 
+                              int32_t *aStatus, 
+                              nsAString & /*aSuggestedDriverVersion*/,
+                              const nsTArray<GfxDriverInfo>& /*aDriverInfo*/, 
+                              OperatingSystem* /*aOS*/ /* = nullptr */)
+{
+  NS_ENSURE_ARG_POINTER(aStatus);
+  *aStatus = nsIGfxInfo::FEATURE_STATUS_OK;
+
+  return NS_OK;
+}
+
+#ifdef DEBUG
+
+// Implement nsIGfxInfoDebug
+
+/* void spoofVendorID (in DOMString aVendorID); */
+NS_IMETHODIMP GfxInfo::SpoofVendorID(const nsAString &)
+{
+  return NS_OK;
+}
+
+/* void spoofDeviceID (in unsigned long aDeviceID); */
+NS_IMETHODIMP GfxInfo::SpoofDeviceID(const nsAString &)
+{
+  return NS_OK;
+}
+
+/* void spoofDriverVersion (in DOMString aDriverVersion); */
+NS_IMETHODIMP GfxInfo::SpoofDriverVersion(const nsAString &)
+{
+  return NS_OK;
+}
+
+/* void spoofOSVersion (in unsigned long aVersion); */
+NS_IMETHODIMP GfxInfo::SpoofOSVersion(uint32_t)
+{
+  return NS_OK;
+}
+
+#endif

--- a/widget/qt/GfxInfo.h
+++ b/widget/qt/GfxInfo.h
@@ -1,0 +1,68 @@
+/* vim: se cin sw=2 ts=2 et : */
+/* -*- Mode: C++; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*-
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef __mozilla_widget_GfxInfo_h__
+#define __mozilla_widget_GfxInfo_h__
+
+#include "GfxInfoBase.h"
+#include "GfxDriverInfo.h"
+
+#include "nsString.h"
+
+namespace mozilla {
+namespace widget {
+
+class GfxInfo : public GfxInfoBase
+{
+public:
+  // We only declare the subset of nsIGfxInfo that we actually implement. The
+  // rest is brought forward from GfxInfoBase.
+  NS_IMETHOD GetD2DEnabled(bool *aD2DEnabled);
+  NS_IMETHOD GetDWriteEnabled(bool *aDWriteEnabled);
+  NS_IMETHOD GetDWriteVersion(nsAString & aDwriteVersion);
+  NS_IMETHOD GetCleartypeParameters(nsAString & aCleartypeParams);
+  NS_IMETHOD GetAdapterDescription(nsAString & aAdapterDescription);
+  NS_IMETHOD GetAdapterDriver(nsAString & aAdapterDriver);
+  NS_IMETHOD GetAdapterVendorID(nsAString & aAdapterVendorID);
+  NS_IMETHOD GetAdapterDeviceID(nsAString & aAdapterDeviceID);
+  NS_IMETHOD GetAdapterSubsysID(nsAString & aAdapterSubsysID);
+  NS_IMETHOD GetAdapterRAM(nsAString & aAdapterRAM);
+  NS_IMETHOD GetAdapterDriverVersion(nsAString & aAdapterDriverVersion);
+  NS_IMETHOD GetAdapterDriverDate(nsAString & aAdapterDriverDate);
+  NS_IMETHOD GetAdapterDescription2(nsAString & aAdapterDescription);
+  NS_IMETHOD GetAdapterDriver2(nsAString & aAdapterDriver);
+  NS_IMETHOD GetAdapterVendorID2(nsAString & aAdapterVendorID);
+  NS_IMETHOD GetAdapterDeviceID2(nsAString & aAdapterDeviceID);
+  NS_IMETHOD GetAdapterSubsysID2(nsAString & aAdapterSubsysID);
+  NS_IMETHOD GetAdapterRAM2(nsAString & aAdapterRAM);
+  NS_IMETHOD GetAdapterDriverVersion2(nsAString & aAdapterDriverVersion);
+  NS_IMETHOD GetAdapterDriverDate2(nsAString & aAdapterDriverDate);
+  NS_IMETHOD GetIsGPU2Active(bool *aIsGPU2Active);
+  using GfxInfoBase::GetFeatureStatus;
+  using GfxInfoBase::GetFeatureSuggestedDriverVersion;
+  using GfxInfoBase::GetWebGLParameter;
+
+  virtual uint32_t OperatingSystemVersion() override;
+
+#ifdef DEBUG
+  NS_DECL_NSIGFXINFODEBUG
+#endif
+
+protected:
+
+  virtual nsresult GetFeatureStatusImpl(int32_t aFeature,
+                                        int32_t *aStatus,
+                                        nsAString & aSuggestedDriverVersion,
+                                        const nsTArray<GfxDriverInfo>& aDriverInfo,
+                                        OperatingSystem* aOS = nullptr);
+  virtual const nsTArray<GfxDriverInfo>& GetGfxDriverInfo();
+};
+
+} // namespace widget
+} // namespace mozilla
+
+#endif /* __mozilla_widget_GfxInfo_h__ */

--- a/widget/qt/moz.build
+++ b/widget/qt/moz.build
@@ -44,6 +44,11 @@ if CONFIG['MOZ_X11']:
     LOCAL_INCLUDES += [
         '../x11',
     ]
+else:
+    SOURCES += [
+        'GfxInfo.cpp',
+    ]
+
 
 #DEFINES['DEBUG_WIDGETS'] = True
 

--- a/widget/qt/nsWidgetFactory.cpp
+++ b/widget/qt/nsWidgetFactory.cpp
@@ -46,6 +46,8 @@
 
 #if defined(MOZ_X11)
 #include "GfxInfoX11.h"
+#else
+#include "GfxInfo.h"
 #endif
 
 using namespace mozilla::widget;
@@ -66,14 +68,12 @@ NS_GENERIC_FACTORY_CONSTRUCTOR_INIT(nsPrintSession, Init)
 NS_GENERIC_FACTORY_CONSTRUCTOR_INIT(nsPrintDialogServiceQt, Init)
 #endif
 
-#if defined(MOZ_X11)
 namespace mozilla {
 namespace widget {
 // This constructor should really be shared with all platforms.
 NS_GENERIC_FACTORY_CONSTRUCTOR_INIT(GfxInfo, Init)
 }
 }
-#endif
 
 
 NS_DEFINE_NAMED_CID(NS_APPSHELL_CID);
@@ -86,9 +86,7 @@ NS_DEFINE_NAMED_CID(NS_IDLE_SERVICE_CID);
 NS_DEFINE_NAMED_CID(NS_TRANSFERABLE_CID);
 NS_DEFINE_NAMED_CID(NS_CLIPBOARD_CID);
 NS_DEFINE_NAMED_CID(NS_CLIPBOARDHELPER_CID);
-#if defined(MOZ_X11)
 NS_DEFINE_NAMED_CID(NS_GFXINFO_CID);
-#endif
 #ifdef NS_PRINTING
 NS_DEFINE_NAMED_CID(NS_PRINTSETTINGSSERVICE_CID);
 NS_DEFINE_NAMED_CID(NS_PRINTER_ENUMERATOR_CID);
@@ -108,9 +106,7 @@ static const mozilla::Module::CIDEntry kWidgetCIDs[] = {
     { &kNS_SCREENMANAGER_CID, false, nullptr, nsScreenManagerQtConstructor },
     { &kNS_TRANSFERABLE_CID, false, nullptr, nsTransferableConstructor },
     { &kNS_WINDOW_CID, false, nullptr, nsWindowConstructor },
-#if defined(MOZ_X11)
     { &kNS_GFXINFO_CID, false, nullptr, mozilla::widget::GfxInfoConstructor },
-#endif
 #ifdef NS_PRINTING
     { &kNS_DEVICE_CONTEXT_SPEC_CID, false, nullptr, nsDeviceContextSpecQtConstructor },
     { &kNS_PRINTDIALOGSERVICE_CID, false, nullptr, nsPrintDialogServiceQtConstructor },
@@ -132,9 +128,7 @@ static const mozilla::Module::ContractIDEntry kWidgetContracts[] = {
     { "@mozilla.org/widgets/child_window/qt;1", &kNS_CHILD_CID },
     { "@mozilla.org/widgets/window/qt;1", &kNS_WINDOW_CID },
     { "@mozilla.org/widget/transferable;1", &kNS_TRANSFERABLE_CID },
-#if defined(MOZ_X11)
     { "@mozilla.org/gfx/info;1", &kNS_GFXINFO_CID },
-#endif
 #ifdef NS_PRINTING
     { "@mozilla.org/gfx/devicecontextspec;1", &kNS_DEVICE_CONTEXT_SPEC_CID },
     { "@mozilla.org/gfx/printerenumerator;1", &kNS_PRINTER_ENUMERATOR_CID },


### PR DESCRIPTION
This basically re-uses dummy gonk implementation of GfxInfo
implementation. Without it pages using WebGL or canvas crash due to null
@mozilla.org/gfx/info;1 service.
