### PR TITLE
Expose an API for throttling nsRefreshDriver.

### DIFF
--- a/embedding/embedlite/EmbedLiteView.cpp
+++ b/embedding/embedlite/EmbedLiteView.cpp
@@ -95,6 +95,14 @@ EmbedLiteView::SetIsFocused(bool aIsFocused)
 }
 
 void
+EmbedLiteView::SetThrottlePainting(bool aThrottle)
+{
+  LOGT();
+  NS_ENSURE_TRUE(mViewParent, );
+  unused << mViewParent->SendSetThrottlePainting(aThrottle);
+}
+
+void
 EmbedLiteView::SuspendTimeouts()
 {
   LOGT();

--- a/embedding/embedlite/EmbedLiteView.h
+++ b/embedding/embedlite/EmbedLiteView.h
@@ -90,6 +90,7 @@ public:
   virtual void LoadURL(const char* aUrl);
   virtual void SetIsActive(bool);
   virtual void SetIsFocused(bool);
+  virtual void SetThrottlePainting(bool);
   virtual void SuspendTimeouts();
   virtual void ResumeTimeouts();
   virtual void GoBack();

--- a/embedding/embedlite/PEmbedLiteView.ipdl
+++ b/embedding/embedlite/PEmbedLiteView.ipdl
@@ -39,6 +39,7 @@ child:
     SetGLViewSize(gfxSize aSize);
     SetIsActive(bool aIsActive);
     SetIsFocused(bool aIsFocused);
+    SetThrottlePainting(bool aThrottle);
     SuspendTimeouts();
     ResumeTimeouts();
     AsyncScrollDOMEvent(gfxRect contentRect, gfxSize scrollSize);

--- a/embedding/embedlite/embedshared/EmbedLiteViewBaseChild.cpp
+++ b/embedding/embedlite/embedshared/EmbedLiteViewBaseChild.cpp
@@ -20,7 +20,7 @@
 #include "nsIFocusManager.h"
 #include "nsFocusManager.h"
 #include "nsIWebBrowserChrome.h"
-
+#include "nsRefreshDriver.h"
 #include "nsIDOMWindowUtils.h"
 #include "nsPIDOMWindow.h"
 #include "nsIDocument.h"
@@ -509,6 +509,14 @@ EmbedLiteViewBaseChild::RecvSetIsFocused(const bool& aIsFocused)
     fm->ClearFocus(mDOMWindow);
     LOGT("Clear browser focus");
   }
+  return true;
+}
+
+bool
+EmbedLiteViewBaseChild::RecvSetThrottlePainting(const bool& aThrottle)
+{
+  LOGT("aThrottle:%d", aThrottle);
+  mHelper->GetPresContext()->RefreshDriver()->SetThrottled(aThrottle);
   return true;
 }
 

--- a/embedding/embedlite/embedshared/EmbedLiteViewBaseChild.h
+++ b/embedding/embedlite/embedshared/EmbedLiteViewBaseChild.h
@@ -118,6 +118,7 @@ protected:
 
   virtual bool RecvSetIsActive(const bool&) override;
   virtual bool RecvSetIsFocused(const bool&) override;
+  virtual bool RecvSetThrottlePainting(const bool&) override;
   virtual bool RecvSuspendTimeouts() override;
   virtual bool RecvResumeTimeouts() override;
   virtual bool RecvLoadFrameScript(const nsString&) override;


### PR DESCRIPTION
In sailfish-browser we're interested in being able to limit view CPU
usage while still keeping it active. Browser live covers are prime user
of such feature. This patch makes it possible to enable layout engine's
refresh driver throttling without fully deactivating the view. When
refresh driver throttling is enabled the engine will update/repaint the
content less often. The frequeency can be tweaked through
layout.throttled_frame_rate pref (defaults to 1).
