### PR TITLE
Add an API for posting external tasks to compositor thread.

### DIFF
--- a/embedding/embedlite/EmbedLiteApp.h
+++ b/embedding/embedlite/EmbedLiteApp.h
@@ -80,6 +80,7 @@ public:
 
   // Delayed post task helper for delayed functions call in main thread
   virtual void* PostTask(EMBEDTaskCallback callback, void* userData, int timeout = 0);
+  virtual void* PostCompositorTask(EMBEDTaskCallback callback, void* userData, int timeout = 0);
   virtual void CancelTask(void* aTask);
 
   // Setup profile path for embedding, or null if embedding supposed to be profile-less


### PR DESCRIPTION
This is a generic API similar to already available EmbedLiteApp::PostTask.
The main difference is, as the function name suggests,
EmbedLiteApp::PostCompostiorTask schedules the callback function to be
executed on gecko compositor thread. In case the compositor was not yet
created by the engine the function returns nullptr.
