### PR TITLE
[embedlite] Add API for setting APZC's DPI

### DIFF
--- a/embedding/embedlite/EmbedLiteView.cpp
+++ b/embedding/embedlite/EmbedLiteView.cpp
@@ -216,6 +216,13 @@ EmbedLiteView::SetViewSize(int width, int height)
 }
 
 void
+EmbedLiteView::SetDPI(const float& dpi)
+{
+  NS_ENSURE_TRUE(mViewImpl, );
+  mViewImpl->SetDPI(dpi);
+}
+
+void
 EmbedLiteView::SetGLViewPortSize(int width, int height)
 {
   LOGNI("sz[%i,%i]", width, height);

--- a/embedding/embedlite/EmbedLiteView.h
+++ b/embedding/embedlite/EmbedLiteView.h
@@ -115,6 +115,9 @@ public:
   // Setup renderable view size
   virtual void SetViewSize(int width, int height);
 
+  // Set DPI for the view (views placed on different screens may get different DPI).
+  virtual void SetDPI(const float& dpi);
+
   // Compositor Interface
   //   PNG Decoded data
   virtual char* GetImageAsURL(int aWidth = -1, int aHeight = -1);

--- a/embedding/embedlite/PEmbedLiteView.ipdl
+++ b/embedding/embedlite/PEmbedLiteView.ipdl
@@ -101,6 +101,11 @@ parent:
     sync GetGLViewSize()
       returns (gfxSize aSize);
 
+    /*
+     * Gets the DPI of the screen corresponding to this view.
+     */
+    sync GetDPI() returns (float value);
+
     sync SyncMessage(nsString aMessage, nsString aJSON)
       returns (nsString[] retval);
 

--- a/embedding/embedlite/embedding.js
+++ b/embedding/embedlite/embedding.js
@@ -74,6 +74,7 @@ pref("apz.fling_curve_function_y2", "1.0");
 pref("apz.fling_curve_threshold_inches_per_ms", "0.03");
 pref("apz.fling_friction", "0.003");
 pref("apz.max_velocity_inches_per_ms", "0.07");
+pref("apz.touch_start_tolerance", "0.027777f");
 
 // Tweak default displayport values to reduce the risk of running out of
 // memory when zooming in

--- a/embedding/embedlite/embedshared/EmbedLitePuppetWidget.cpp
+++ b/embedding/embedlite/embedshared/EmbedLitePuppetWidget.cpp
@@ -95,6 +95,7 @@ EmbedLitePuppetWidget::EmbedLitePuppetWidget(EmbedLiteViewChildIface* aEmbed, ui
   , mIMEComposing(false)
   , mParent(nullptr)
   , mId(aId)
+  , mDPI(-1.0)
 {
   MOZ_COUNT_CTOR(EmbedLitePuppetWidget);
   LOGT("this:%p", this);
@@ -560,6 +561,21 @@ EmbedLitePuppetWidget::GetLayerManager(PLayerTransactionChild* aShadowManager,
 
   return mLayerManager;
 }
+
+float
+EmbedLitePuppetWidget::GetDPI()
+{
+  if (mDPI < 0) {
+    if (mEmbed) {
+      mEmbed->GetDPI(&mDPI);
+    } else {
+      mDPI = nsBaseWidget::GetDPI();
+    }
+  }
+
+  return mDPI;
+}
+
 
 CompositorParent*
 EmbedLitePuppetWidget::NewCompositorParent(int aSurfaceWidth, int aSurfaceHeight)

--- a/embedding/embedlite/embedshared/EmbedLitePuppetWidget.h
+++ b/embedding/embedlite/embedshared/EmbedLitePuppetWidget.h
@@ -145,6 +145,7 @@ public:
   virtual void CreateCompositor(int aWidth, int aHeight);
   virtual void CreateCompositor();
   virtual nsIntRect GetNaturalBounds();
+  virtual float GetDPI() override;
 
   /**
    * Called before the LayerManager draws the layer tree.
@@ -189,6 +190,7 @@ private:
   nsCOMPtr<nsIWidget> mParent;
 
   uint32_t mId;
+  float mDPI;
 };
 
 }  // namespace widget

--- a/embedding/embedlite/embedshared/EmbedLiteViewBaseChild.cpp
+++ b/embedding/embedlite/embedshared/EmbedLiteViewBaseChild.cpp
@@ -332,6 +332,12 @@ EmbedLiteViewBaseChild::ZoomToRect(const uint32_t& aPresShellId,
 }
 
 bool
+EmbedLiteViewBaseChild::GetDPI(float* aDPI)
+{
+  return SendGetDPI(aDPI);
+}
+
+bool
 EmbedLiteViewBaseChild::UpdateZoomConstraints(const uint32_t& aPresShellId,
                                                 const ViewID& aViewId,
                                                 const bool& aIsRoot,

--- a/embedding/embedlite/embedshared/EmbedLiteViewBaseChild.h
+++ b/embedding/embedlite/embedshared/EmbedLiteViewBaseChild.h
@@ -63,6 +63,7 @@ public:
 
   virtual nsIWebNavigation* WebNavigation() override;
   virtual nsIWidget* WebWidget() override;
+  virtual bool GetDPI(float* aDPI) override;
 
 /*---------TabChildIface---------------*/
 

--- a/embedding/embedlite/embedshared/EmbedLiteViewBaseParent.cpp
+++ b/embedding/embedlite/embedshared/EmbedLiteViewBaseParent.cpp
@@ -29,6 +29,7 @@ EmbedLiteViewBaseParent::EmbedLiteViewBaseParent(const uint32_t& id, const uint3
   : mId(id)
   , mViewAPIDestroyed(false)
   , mCompositor(nullptr)
+  , mDPI(-1.0)
   , mRotation(ROTATION_0)
   , mPendingRotation(false)
   , mUILoop(MessageLoop::current())
@@ -87,6 +88,9 @@ EmbedLiteViewBaseParent::UpdateScrollController()
   if (mCompositor) {
     mRootLayerTreeId = mCompositor->RootLayerTreeId();
     mController->SetManagerByRootLayerTreeId(mRootLayerTreeId);
+    if (mDPI > 0) {
+      mController->GetManager()->SetDPI(mDPI);
+    }
     CompositorParent::SetControllerForLayerTree(mRootLayerTreeId, mController);
   }
 
@@ -390,10 +394,31 @@ EmbedLiteViewBaseParent::SetViewSize(int width, int height)
   return NS_OK;
 }
 
+NS_IMETHODIMP
+EmbedLiteViewBaseParent::SetDPI(float dpi)
+{
+  mDPI = dpi;
+
+  if (mController->GetManager()) {
+    mController->GetManager()->SetDPI(mDPI);
+  }
+
+  return NS_OK;
+}
+
 bool
 EmbedLiteViewBaseParent::RecvGetGLViewSize(gfxSize* aSize)
 {
   *aSize = mGLViewPortSize;
+  return true;
+}
+
+bool
+EmbedLiteViewBaseParent::RecvGetDPI(float* aValue)
+{
+  NS_ENSURE_TRUE((mDPI > 0), false);
+
+  *aValue = mDPI;
   return true;
 }
 

--- a/embedding/embedlite/embedshared/EmbedLiteViewBaseParent.h
+++ b/embedding/embedlite/embedshared/EmbedLiteViewBaseParent.h
@@ -110,6 +110,8 @@ protected:
                                    const int32_t& aFocusChange) override;
   virtual bool RecvGetGLViewSize(gfxSize* aSize) override;
 
+  virtual bool RecvGetDPI(float* aValue) override;
+
 private:
   friend class EmbedContentController;
   friend class EmbedLiteCompositorParent;
@@ -123,6 +125,7 @@ private:
 
   ScreenIntSize mViewSize;
   gfxSize mGLViewPortSize;
+  float mDPI;
 
   // Cache initial values.
   mozilla::ScreenRotation mRotation;

--- a/embedding/embedlite/embedshared/EmbedLiteViewChildIface.h
+++ b/embedding/embedlite/embedshared/EmbedLiteViewChildIface.h
@@ -53,6 +53,7 @@ public:
   virtual bool DoCallRpcMessage(const char16_t* aMessageName,
                                 const char16_t* aMessage,
                                 InfallibleTArray<nsString>* aJSONRetVal) = 0;
+  virtual bool GetDPI(float* aDPI) = 0;
 
   /**
    * Relay given frame metrics to listeners subscribed via EmbedLiteAppService

--- a/embedding/embedlite/embedshared/EmbedLiteViewIface.idl
+++ b/embedding/embedlite/embedshared/EmbedLiteViewIface.idl
@@ -33,6 +33,7 @@ interface EmbedLiteViewIface
 {
     void RenderToImage(in buffer aData, in int32_t aWidth, in int32_t aHeigth, in int32_t aStride, in int32_t aDepth);
     void SetViewSize(in int32_t aWidth, in int32_t aHeight);
+    void SetDPI(in float dpi);
     void SetGLViewPortSize(in int32_t aWidth, in int32_t aHeight);
     void SetScreenRotation([const] in ScreenRotation rotation);
     void ScheduleUpdate();


### PR DESCRIPTION
While it is possible to set DPI in EmbedlitePuppetWidget class using
the gfxPlatform::GetDPI() call this aproach doesn't seem to be plausible,
because theoretically the device may have more than one screen with different
DPI. Thus gfxPlatform::GetDPI() is not used neither in B2G nor in Metro.
Instead these two embeddings set DPI at the moment of view creation.
And their PuppetWidget works as a proxy for the real window which lives
in the UI thread. Particularly PuppetWidget forwards GetDPI() requests
from TabChild to TabParent synchronously. And TabParent maintains its
own copy of DPI value set during window creation.

So, this commit also overrides GetDPI() for EmbedlitePuppetWidget.
First call to this methods gets forwarded synchronously to the UI thread
with the help of EmbedLiteViewBaseChild. The result is cached. After
that only cached value is returned.
