### PR TITLE
Add API for setting APZC's DPI

### DIFF
--- a/embedding/embedlite/EmbedLiteView.cpp
+++ b/embedding/embedlite/EmbedLiteView.cpp
@@ -212,6 +212,13 @@ EmbedLiteView::SetMargins(int top, int right, int bottom, int left)
 }
 
 void
+EmbedLiteView::SetDPI(const float& dpi)
+{
+  NS_ENSURE_TRUE(mViewImpl, );
+  mViewImpl->SetDPI(dpi);
+}
+
+void
 EmbedLiteView::ReceiveInputEvent(const InputData& aEvent)
 {
   NS_ENSURE_TRUE(mViewImpl,);

--- a/embedding/embedlite/EmbedLiteView.h
+++ b/embedding/embedlite/EmbedLiteView.h
@@ -99,6 +99,9 @@ public:
 
   virtual void SetMargins(int top, int right, int bottom, int left);
 
+  // Set DPI for the view (views placed on different screens may get different DPI).
+  virtual void SetDPI(const float& dpi);
+
   // Scripting Interface, allow to extend embedding API by creating
   // child js scripts and messaging interface.
   // and do communication between UI and Content child via json messages.

--- a/embedding/embedlite/PEmbedLiteView.ipdl
+++ b/embedding/embedlite/PEmbedLiteView.ipdl
@@ -101,6 +101,11 @@ parent:
     SetBackgroundColor(nscolor color);
     ContentReceivedInputBlock(ScrollableLayerGuid aGuid, uint64_t aInputBlockId, bool aPreventDefault);
 
+    /*
+     * Gets the DPI of the screen corresponding to this view.
+     */
+    sync GetDPI() returns (float value);
+
     sync SyncMessage(nsString aMessage, nsString aJSON)
       returns (nsString[] retval);
 

--- a/embedding/embedlite/embedding.js
+++ b/embedding/embedlite/embedding.js
@@ -75,6 +75,7 @@ pref("apz.fling_curve_function_y2", "1.0");
 pref("apz.fling_curve_threshold_inches_per_ms", "0.03");
 pref("apz.fling_friction", "0.003");
 pref("apz.max_velocity_inches_per_ms", "0.07");
+pref("apz.touch_start_tolerance", "0.027777f");
 
 // Tweak default displayport values to reduce the risk of running out of
 // memory when zooming in

--- a/embedding/embedlite/embedshared/EmbedLitePuppetWidget.cpp
+++ b/embedding/embedlite/embedshared/EmbedLitePuppetWidget.cpp
@@ -91,6 +91,7 @@ EmbedLitePuppetWidget::EmbedLitePuppetWidget(EmbedLiteWindowBaseChild* window,
   , mParent(nullptr)
   , mRotation(ROTATION_0)
   , mMargins(0, 0, 0, 0)
+  , mDPI(-1.0)
 {
   MOZ_COUNT_CTOR(EmbedLitePuppetWidget);
   LOGT("this:%p", this);
@@ -642,6 +643,21 @@ EmbedLitePuppetWidget::GetLayerManager(PLayerTransactionChild* aShadowManager,
 
   return mLayerManager;
 }
+
+float
+EmbedLitePuppetWidget::GetDPI()
+{
+  if (mDPI < 0) {
+    if (mView) {
+      mView->GetDPI(&mDPI);
+    } else {
+      mDPI = nsBaseWidget::GetDPI();
+    }
+  }
+
+  return mDPI;
+}
+
 
 CompositorParent*
 EmbedLitePuppetWidget::NewCompositorParent(int aSurfaceWidth, int aSurfaceHeight)

--- a/embedding/embedlite/embedshared/EmbedLitePuppetWidget.h
+++ b/embedding/embedlite/embedshared/EmbedLitePuppetWidget.h
@@ -152,6 +152,8 @@ public:
   virtual void CreateCompositor() override;
   virtual void CreateCompositor(int aWidth, int aHeight) override;
 
+  virtual float GetDPI() override;
+
   /**
    * Called before the LayerManager draws the layer tree.
    *
@@ -216,6 +218,7 @@ private:
   nsIntRect mNaturalBounds;
   nsIntMargin mMargins;
   ObserverArray mObservers;
+  float mDPI;
 };
 
 }  // namespace widget

--- a/embedding/embedlite/embedshared/EmbedLiteViewBaseChild.cpp
+++ b/embedding/embedlite/embedshared/EmbedLiteViewBaseChild.cpp
@@ -350,6 +350,12 @@ EmbedLiteViewBaseChild::ZoomToRect(const uint32_t& aPresShellId,
 }
 
 bool
+EmbedLiteViewBaseChild::GetDPI(float* aDPI)
+{
+  return SendGetDPI(aDPI);
+}
+
+bool
 EmbedLiteViewBaseChild::UpdateZoomConstraints(const uint32_t& aPresShellId,
                                               const ViewID& aViewId,
                                               const bool& aIsRoot,

--- a/embedding/embedlite/embedshared/EmbedLiteViewBaseChild.h
+++ b/embedding/embedlite/embedshared/EmbedLiteViewBaseChild.h
@@ -66,6 +66,7 @@ public:
 
   virtual nsIWebNavigation* WebNavigation() override;
   virtual nsIWidget* WebWidget() override;
+  virtual bool GetDPI(float* aDPI) override;
 
 /*---------TabChildIface---------------*/
 

--- a/embedding/embedlite/embedshared/EmbedLiteViewBaseParent.cpp
+++ b/embedding/embedlite/embedshared/EmbedLiteViewBaseParent.cpp
@@ -25,6 +25,7 @@ EmbedLiteViewBaseParent::EmbedLiteViewBaseParent(const uint32_t& windowId, const
   , mViewAPIDestroyed(false)
   , mWindow(*EmbedLiteWindowBaseParent::From(windowId))
   , mCompositor(nullptr)
+  , mDPI(-1.0)
   , mUILoop(MessageLoop::current())
   , mLastIMEState(0)
   , mUploadTexture(0)
@@ -73,6 +74,9 @@ EmbedLiteViewBaseParent::UpdateScrollController()
   if (mCompositor) {
     mRootLayerTreeId = mCompositor->RootLayerTreeId();
     mController->SetManagerByRootLayerTreeId(mRootLayerTreeId);
+    if (mDPI > 0) {
+      mController->GetManager()->SetDPI(mDPI);
+    }
     CompositorParent::SetControllerForLayerTree(mRootLayerTreeId, mController);
   }
 }
@@ -342,6 +346,28 @@ EmbedLiteViewBaseParent::RecvRpcMessage(const nsString& aMessage,
                                           InfallibleTArray<nsString>* aJSONRetVal)
 {
   return RecvSyncMessage(aMessage, aJSON, aJSONRetVal);
+}
+
+
+NS_IMETHODIMP
+EmbedLiteViewBaseParent::SetDPI(float dpi)
+{
+  mDPI = dpi;
+
+  if (mController->GetManager()) {
+    mController->GetManager()->SetDPI(mDPI);
+  }
+
+  return NS_OK;
+}
+
+bool
+EmbedLiteViewBaseParent::RecvGetDPI(float* aValue)
+{
+  NS_ENSURE_TRUE((mDPI > 0), false);
+
+  *aValue = mDPI;
+  return true;
 }
 
 void

--- a/embedding/embedlite/embedshared/EmbedLiteViewBaseParent.h
+++ b/embedding/embedlite/embedshared/EmbedLiteViewBaseParent.h
@@ -118,6 +118,8 @@ protected:
   // EmbedLiteWindowParentObserver:
   void CompositorCreated() override;
 
+  virtual bool RecvGetDPI(float* aValue) override;
+
 private:
   friend class EmbedContentController;
   friend class EmbedLiteCompositorParent;
@@ -132,6 +134,8 @@ private:
   bool mViewAPIDestroyed;
   EmbedLiteWindowBaseParent& mWindow;
   RefPtr<EmbedLiteCompositorParent> mCompositor;
+
+  float mDPI;
 
   MessageLoop* mUILoop;
   int mLastIMEState;

--- a/embedding/embedlite/embedshared/EmbedLiteViewChildIface.h
+++ b/embedding/embedlite/embedshared/EmbedLiteViewChildIface.h
@@ -52,6 +52,7 @@ public:
   virtual bool DoCallRpcMessage(const char16_t* aMessageName,
                                 const char16_t* aMessage,
                                 InfallibleTArray<nsString>* aJSONRetVal) = 0;
+  virtual bool GetDPI(float* aDPI) = 0;
 
   /**
    * Relay given frame metrics to listeners subscribed via EmbedLiteAppService

--- a/embedding/embedlite/embedshared/EmbedLiteViewIface.idl
+++ b/embedding/embedlite/embedshared/EmbedLiteViewIface.idl
@@ -31,6 +31,7 @@ class nsString;
 [scriptable, uuid(6d7750f8-e028-4445-a0cb-d9ce28fb03dd)]
 interface EmbedLiteViewIface
 {
+    void SetDPI(in float dpi);
     void ReceiveInputEvent([const] in InputData aEvent);
     void TextEvent(in string aComposite, in string aPreEdit);
     void SendKeyPress(in int32_t aDomKeyCode, in int32_t aModifiers, in int32_t aCharCode);


### PR DESCRIPTION
While it is possible to set DPI in EmbedlitePuppetWidget class using
the gfxPlatform::GetDPI() call this aproach doesn't seem to be plausible,
because theoretically the device may have more than one screen with different
DPI. Thus gfxPlatform::GetDPI() is not used neither in B2G nor in Metro.
Instead these two embeddings set DPI at the moment of view creation.
And their PuppetWidget works as a proxy for the real window which lives
in the UI thread. Particularly PuppetWidget forwards GetDPI() requests
from TabChild to TabParent synchronously. And TabParent maintains its
own copy of DPI value set during window creation.

So, this commit also overrides GetDPI() for EmbedlitePuppetWidget.
First call to this methods gets forwarded synchronously to the UI thread
with the help of EmbedLiteViewBaseChild. The result is cached. After
that only cached value is returned.

Conflicts:
    embedding/embedlite/EmbedLiteView.cpp
    embedding/embedlite/EmbedLiteView.h
    embedding/embedlite/embedshared/EmbedLitePuppetWidget.cpp
    embedding/embedlite/embedshared/EmbedLitePuppetWidget.h
    embedding/embedlite/embedshared/EmbedLiteViewBaseParent.cpp
    embedding/embedlite/embedshared/EmbedLiteViewBaseParent.h
    embedding/embedlite/embedshared/EmbedLiteViewIface.idl
