### PR TITLE
[embedlite] Update viewport upon margin update

### DIFF
--- a/embedding/embedlite/embedshared/EmbedLiteViewBaseChild.cpp
+++ b/embedding/embedlite/embedshared/EmbedLiteViewBaseChild.cpp
@@ -559,7 +559,15 @@ EmbedLiteViewBaseChild::RecvSetMargins(const int& aTop, const int& aRight,
     EmbedLitePuppetWidget* widget = static_cast<EmbedLitePuppetWidget*>(mWidget.get());
     widget->SetMargins(mMargins);
     widget->UpdateSize();
+
+    // Report update for the tab child helper. This triggers update for the viewport.
+    nsIntRect bounds;
+    mWindow->GetWidget()->GetBounds(bounds);
+    bounds.Deflate(mMargins);
+    gfxSize size(bounds.width, bounds.height);
+    mHelper->ReportSizeUpdate(size);
   }
+
   return true;
 }
 


### PR DESCRIPTION
Fixes controls to be visible within the given margins
e.g. in m.here.com and www.google.fi/maps.
