### PR TITLE
[embedlite] Send AsyncScrollDOMEvent only for the root frame. Fixes JB#32828

### DIFF
--- a/embedding/embedlite/embedthread/EmbedContentController.cpp
+++ b/embedding/embedlite/embedthread/EmbedContentController.cpp
@@ -122,7 +122,7 @@ void EmbedContentController::SendAsyncScrollDOMEvent(bool aIsRoot,
   gfxRect rect(aContentRect.x, aContentRect.y, aContentRect.width, aContentRect.height);
   gfxSize size(aScrollableSize.width, aScrollableSize.height);
 
-  if (mRenderFrame && !GetListener()->SendAsyncScrollDOMEvent(rect, size)) {
+  if (mRenderFrame && aIsRoot && !GetListener()->SendAsyncScrollDOMEvent(rect, size)) {
     unused << mRenderFrame->SendAsyncScrollDOMEvent(rect, size);
   }
 }


### PR DESCRIPTION
This guard already exists in embedlite branch.

Signed-off-by: Raine Makelainen raine.makelainen@jolla.com
