### PR TITLE
Emulate content frame message managers in EmbedLite

### DIFF
--- a/embedding/embedlite/embedshared/EmbedLiteViewBaseChild.cpp
+++ b/embedding/embedlite/embedshared/EmbedLiteViewBaseChild.cpp
@@ -248,6 +248,7 @@ EmbedLiteViewBaseChild::InitGeckoWindow(const uint32_t& parentId, const bool& is
   }
 
   mHelper = new TabChildHelper(this);
+  mChrome->SetTabChildHelper(mHelper.get());
 
   OnGeckoWindowInitialized();
 

--- a/embedding/embedlite/modules/EmbedFrame.cpp
+++ b/embedding/embedlite/modules/EmbedFrame.cpp
@@ -1,0 +1,32 @@
+/* -*- Mode: C++; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "EmbedFrame.h"
+
+EmbedFrame::EmbedFrame()
+{
+}
+
+EmbedFrame::~EmbedFrame()
+{
+}
+
+NS_IMPL_ISUPPORTS(EmbedFrame, nsIEmbedFrame)
+
+NS_IMETHODIMP
+EmbedFrame::GetContentWindow(nsIDOMWindow** aWindow)
+{
+  nsCOMPtr<nsIDOMWindow> window = mWindow;
+  window.forget(aWindow);
+  return NS_OK;
+}
+
+NS_IMETHODIMP
+EmbedFrame::GetMessageManager(nsIContentFrameMessageManager** aMessageManager)
+{
+  nsCOMPtr<nsIContentFrameMessageManager> mm = mMessageManager;
+  mm.forget(aMessageManager);
+  return NS_OK;
+}

--- a/embedding/embedlite/modules/EmbedFrame.h
+++ b/embedding/embedlite/modules/EmbedFrame.h
@@ -1,0 +1,27 @@
+/* -*- Mode: C++; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef EMBEDFRAME_H
+#define EMBEDFRAME_H
+
+#include "nsIEmbedFrame.h"
+#include "nsCOMPtr.h"
+
+class EmbedFrame : public nsIEmbedFrame
+{
+public:
+  NS_DECL_ISUPPORTS
+  NS_DECL_NSIEMBEDFRAME
+
+  EmbedFrame();
+
+  nsCOMPtr<nsIDOMWindow> mWindow;
+  nsCOMPtr<nsIContentFrameMessageManager> mMessageManager;
+
+private:
+  virtual ~EmbedFrame();
+};
+
+#endif

--- a/embedding/embedlite/modules/nsIEmbedFrame.idl
+++ b/embedding/embedlite/modules/nsIEmbedFrame.idl
@@ -1,0 +1,18 @@
+/* -*- Mode: C++; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "nsISupports.idl"
+#include "nsIDOMWindow.idl"
+#include "nsIMessageManager.idl"
+
+interface nsIDOMWindow;
+interface nsIContentFrameMessageManager;
+
+[scriptable, uuid(48738828-adbe-4106-a453-0d6e0965d6f8)]
+interface nsIEmbedFrame : nsISupports
+{
+  readonly attribute nsIDOMWindow contentWindow;
+  readonly attribute nsIContentFrameMessageManager messageManager;
+};

--- a/embedding/embedlite/moz.build
+++ b/embedding/embedlite/moz.build
@@ -19,6 +19,7 @@ FINAL_LIBRARY = 'xul'
 XPIDL_SOURCES += [
     'embedshared/EmbedLiteViewIface.idl',
     'modules/nsIEmbedAppService.idl',
+    'modules/nsIEmbedFrame.idl',
     'modules/nsIEmbedLiteJSON.idl',
     'utils/nsIEmbedBrowserChromeListener.idl',
 ]
@@ -62,6 +63,7 @@ UNIFIED_SOURCES += [
     'embedthread/EmbedLiteAppThreadChild.cpp',
     'embedthread/EmbedLiteAppThreadParent.cpp',
     'embedthread/EmbedLiteViewThreadChild.cpp',
+    'modules/EmbedFrame.cpp',
     'modules/EmbedLiteAppService.cpp',
     'modules/EmbedLiteJSON.cpp',
     'utils/DirProvider.cpp',

--- a/embedding/embedlite/utils/TabChildHelper.cpp
+++ b/embedding/embedlite/utils/TabChildHelper.cpp
@@ -31,6 +31,7 @@
 #include "nsLayoutUtils.h"
 #include "nsIDocumentInlines.h"
 #include "APZCCallbackHelper.h"
+#include "EmbedFrame.h"
 
 static const char BEFORE_FIRST_PAINT[] = "before-first-paint";
 static const char CANCEL_DEFAULT_PAN_ZOOM[] = "cancel-default-pan-zoom";
@@ -359,6 +360,22 @@ TabChildHelper::DoSendAsyncMessage(JSContext* aCx,
                                    JS::Handle<JSObject *> aCpows,
                                    nsIPrincipal* aPrincipal)
 {
+  nsCOMPtr<nsIMessageBroadcaster> globalIMessageManager =
+      do_GetService("@mozilla.org/globalmessagemanager;1");
+  nsRefPtr<nsFrameMessageManager> globalMessageManager =
+      static_cast<nsFrameMessageManager*>(globalIMessageManager.get());
+  nsRefPtr<nsFrameMessageManager> contentFrameMessageManager =
+      static_cast<nsFrameMessageManager*>(mTabChildGlobal->mMessageManager.get());
+
+  nsCOMPtr<nsPIDOMWindow> pwindow = do_GetInterface(WebNavigation());
+  nsCOMPtr<nsIDOMWindow> window = do_QueryInterface(pwindow);
+  nsRefPtr<EmbedFrame> embedFrame = new EmbedFrame();
+  embedFrame->mWindow = window;
+  embedFrame->mMessageManager = mTabChildGlobal;
+  SameProcessCpowHolder cpows(js::GetRuntime(aCx), aCpows);
+  globalMessageManager->ReceiveMessage(embedFrame, aMessage, false, &aData, &cpows, aPrincipal, nullptr);
+  contentFrameMessageManager->ReceiveMessage(embedFrame, aMessage, false, &aData, &cpows, aPrincipal, nullptr);
+
   if (!mView->HasMessageListener(aMessage)) {
     LOGW("Message not registered msg:%s\n", NS_ConvertUTF16toUTF8(aMessage).get());
     return true;

--- a/embedding/embedlite/utils/TabChildHelper.cpp
+++ b/embedding/embedlite/utils/TabChildHelper.cpp
@@ -158,6 +158,7 @@ TabChildHelper::Unload()
 
 NS_INTERFACE_MAP_BEGIN_CYCLE_COLLECTION_INHERITED(TabChildHelper)
   NS_INTERFACE_MAP_ENTRY(nsIDOMEventListener)
+  NS_INTERFACE_MAP_ENTRY(nsITabChild)
   NS_INTERFACE_MAP_ENTRY(nsIObserver)
 NS_INTERFACE_MAP_END_INHERITING(TabChildBase)
 
@@ -495,3 +496,52 @@ TabChildHelper::ReportSizeUpdate(const gfxSize& aSize)
 
   HandlePossibleViewportChange(oldScreenSize);
 }
+// -- nsITabChild --------------
+
+NS_IMETHODIMP
+TabChildHelper::GetMessageManager(nsIContentFrameMessageManager** aResult)
+{
+  if (mTabChildGlobal) {
+    NS_ADDREF(*aResult = mTabChildGlobal);
+    return NS_OK;
+  }
+  *aResult = nullptr;
+  return NS_ERROR_FAILURE;
+}
+
+NS_IMETHODIMP
+TabChildHelper::GetWebBrowserChrome(nsIWebBrowserChrome3** aWebBrowserChrome)
+{
+  NS_IF_ADDREF(*aWebBrowserChrome = mWebBrowserChrome);
+  return NS_OK;
+}
+
+NS_IMETHODIMP
+TabChildHelper::SetWebBrowserChrome(nsIWebBrowserChrome3* aWebBrowserChrome)
+{
+  mWebBrowserChrome = aWebBrowserChrome;
+  return NS_OK;
+}
+
+void
+TabChildHelper::SendRequestFocus(bool aCanFocus)
+{
+  LOGNI();
+}
+
+void
+TabChildHelper::EnableDisableCommands(const nsAString& aAction,
+                                      nsTArray<nsCString>& aEnabledCommands,
+                                      nsTArray<nsCString>& aDisabledCommands)
+{
+  LOGNI();
+}
+
+NS_IMETHODIMP
+TabChildHelper::GetTabId(uint64_t* aId)
+{
+  *aId = mView->GetID();
+  return NS_OK;
+}
+
+// -- end of nsITabChild -------

--- a/embedding/embedlite/utils/TabChildHelper.h
+++ b/embedding/embedlite/utils/TabChildHelper.h
@@ -10,6 +10,7 @@
 #include "FrameMetrics.h"
 #include "nsFrameMessageManager.h"
 #include "nsIWebNavigation.h"
+#include "nsITabChild.h"
 #include "nsIWidget.h"
 #include "InputData.h"
 #include "nsDataHashtable.h"
@@ -27,6 +28,7 @@ namespace embedlite {
 class EmbedLiteViewChildIface;
 class TabChildHelper : public mozilla::dom::TabChildBase,
                        public nsIDOMEventListener,
+                       public nsITabChild,
                        public nsIObserver
 {
 public:
@@ -35,6 +37,7 @@ public:
 
   NS_DECL_ISUPPORTS_INHERITED
   NS_DECL_NSIDOMEVENTLISTENER
+  NS_DECL_NSITABCHILD
   NS_DECL_NSIOBSERVER
 
   bool RecvUpdateFrame(const mozilla::layers::FrameMetrics& aFrameMetrics);

--- a/embedding/embedlite/utils/WebBrowserChrome.h
+++ b/embedding/embedlite/utils/WebBrowserChrome.h
@@ -8,7 +8,7 @@
 
 #include "nsCOMPtr.h"
 #include "nsIWebBrowser.h"
-#include "nsIWebBrowserChrome.h"
+#include "nsIWebBrowserChrome2.h"
 #include "nsIWebBrowserChromeFocus.h"
 #include "nsIWebProgressListener.h"
 #include "nsIEmbeddingSiteWindow.h"
@@ -23,8 +23,14 @@
 
 #define kNotFound -1
 
+namespace mozilla {
+namespace embedlite {
+  class TabChildHelper;
+}
+}
+
 class nsIEmbedBrowserChromeListener;
-class WebBrowserChrome : public nsIWebBrowserChrome,
+class WebBrowserChrome : public nsIWebBrowserChrome2,
                          public nsIWebProgressListener,
                          public nsIWebBrowserChromeFocus,
                          public nsIEmbeddingSiteWindow,
@@ -35,6 +41,7 @@ class WebBrowserChrome : public nsIWebBrowserChrome,
 public:
   NS_DECL_ISUPPORTS
   NS_DECL_NSIWEBBROWSERCHROME
+  NS_DECL_NSIWEBBROWSERCHROME2
   NS_DECL_NSIWEBPROGRESSLISTENER
   NS_DECL_NSIWEBBROWSERCHROMEFOCUS
   NS_DECL_NSIEMBEDDINGSITEWINDOW
@@ -46,6 +53,8 @@ public:
 
   void SetEventHandler();
   void RemoveEventHandler();
+
+  void SetTabChildHelper(mozilla::embedlite::TabChildHelper* aHelper);
 
 protected:
   virtual ~WebBrowserChrome();
@@ -71,6 +80,7 @@ private:
   nsCOMPtr<nsIObserverService> mObserverService;
   nsIEmbedBrowserChromeListener* mListener;
   nsString mTitle;
+  nsRefPtr<mozilla::embedlite::TabChildHelper> mHelper;
 };
 
 #endif /* Header guard */

--- a/embedding/embedlite/utils/WindowCreator.cpp
+++ b/embedding/embedlite/utils/WindowCreator.cpp
@@ -12,6 +12,9 @@
 #include <stdio.h>
 #include "EmbedLiteViewChildIface.h"
 #include "EmbedLiteAppChildIface.h"
+#include "nsCOMPtr.h"
+#include "nsIThread.h"
+#include "nsThreadUtils.h"           // for NS_GetCurrentThread
 
 using namespace mozilla::embedlite;
 


### PR DESCRIPTION
The new multi-process architecture of gecko relies on two trees of message managers [1]. The patch just emulates presence of the managers in EmbedLite because they live in the same thread. This is needed to make two parts of LoginManager work again (LoginManagerParent and LoginManagerContent).

[1] https://developer.mozilla.org/en-US/Firefox/Multiprocess_Firefox/Message_Manager/Message_manager_overview
